### PR TITLE
guard against undefined pixel results

### DIFF
--- a/dist/browser-connector.js
+++ b/dist/browser-connector.js
@@ -124,7 +124,7 @@
 
 	var _mapdClientV2 = _interopRequireDefault(_mapdClientV);
 
-	var _processQueryResults = __webpack_require__(117);
+	var _processQueryResults = __webpack_require__(118);
 
 	var _processQueryResults2 = _interopRequireDefault(_processQueryResults);
 
@@ -134,7 +134,7 @@
 
 	function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-	var _ref = isNodeRuntime() && __webpack_require__(116) || window,
+	var _ref = isNodeRuntime() && __webpack_require__(117) || window,
 	    TDatumType = _ref.TDatumType,
 	    TEncodingType = _ref.TEncodingType,
 	    TPixel = _ref.TPixel; // eslint-disable-line global-require
@@ -143,7 +143,7 @@
 	var MapDThrift = isNodeRuntime() && __webpack_require__(13); // eslint-disable-line global-require
 	var Thrift = isNodeRuntime() && __webpack_require__(14) || window.Thrift; // eslint-disable-line global-require
 	var thriftWrapper = Thrift;
-	var parseUrl = isNodeRuntime() && __webpack_require__(59).parse; // eslint-disable-line global-require
+	var parseUrl = isNodeRuntime() && __webpack_require__(60).parse; // eslint-disable-line global-require
 	if (isNodeRuntime()) {
 	  // Because browser Thrift and Node Thrift are exposed slightly differently.
 	  Thrift = Thrift.Thrift;
@@ -1119,6 +1119,7 @@
 	  }, {
 	    key: "processPixelResults",
 	    value: function processPixelResults(callbacks, error, results) {
+	      var hasCallbacks = Boolean(callbacks);
 	      callbacks = Array.isArray(callbacks) ? callbacks : [callbacks];
 	      results = Array.isArray(results) ? results.pixel_rows : [results];
 	      var numPixels = results.length;
@@ -1128,13 +1129,22 @@
 	        query: "pixel request",
 	        queryId: -2
 	      };
-	      for (var p = 0; p < numPixels; p++) {
-	        results[p].row_set = this.processResults(processResultsOptions, results[p]);
+	      if (error) {
+	        if (hasCallbacks) {
+	          return callbacks.pop()(error);
+	        } else {
+	          throw error;
+	        }
+	      } else {
+	        for (var p = 0; p < numPixels; p++) {
+	          results[p].row_set = this.processResults(processResultsOptions, results[p]);
+	        }
+	        if (hasCallbacks) {
+	          return callbacks.pop()(null, results);
+	        } else {
+	          return results;
+	        }
 	      }
-	      if (!callbacks) {
-	        return results;
-	      }
-	      callbacks.pop()(error, results);
 	    }
 
 	    /**
@@ -1600,7 +1610,7 @@
 	exports.wrapMethod = wrapMethod;
 	exports.wrapWithErrorHandling = wrapWithErrorHandling;
 	var MapDClient = typeof window !== "undefined" && window.MapDClient || __webpack_require__(13).Client; // eslint-disable-line global-require
-	var TMapDException = typeof window !== "undefined" && window.TMapDException || __webpack_require__(116).TMapDException; // eslint-disable-line global-require
+	var TMapDException = typeof window !== "undefined" && window.TMapDException || __webpack_require__(117).TMapDException; // eslint-disable-line global-require
 	var Thrift = typeof window !== "undefined" && window.Thrift || __webpack_require__(14).Thrift; // eslint-disable-line global-require
 
 	function isResultError(result) {
@@ -1672,7 +1682,7 @@
 	var Thrift = thrift.Thrift;
 	var Q = thrift.Q;
 
-	var ttypes = __webpack_require__(116);
+	var ttypes = __webpack_require__(117);
 	//HELPER FUNCTIONS AND STRUCTURES
 
 	var MapD_connect_args = function MapD_connect_args(args) {
@@ -12455,28 +12465,28 @@
 	exports.createHttpConnection = httpConnection.createHttpConnection;
 	exports.createHttpClient = httpConnection.createHttpClient;
 
-	var wsConnection = __webpack_require__(66);
+	var wsConnection = __webpack_require__(67);
 	exports.WSConnection = wsConnection.WSConnection;
 	exports.createWSConnection = wsConnection.createWSConnection;
 	exports.createWSClient = wsConnection.createWSClient;
 
-	var xhrConnection = __webpack_require__(75);
+	var xhrConnection = __webpack_require__(76);
 	exports.XHRConnection = xhrConnection.XHRConnection;
 	exports.createXHRConnection = xhrConnection.createXHRConnection;
 	exports.createXHRClient = xhrConnection.createXHRClient;
 
-	var server = __webpack_require__(76);
+	var server = __webpack_require__(77);
 	exports.createServer = server.createServer;
 	exports.createMultiplexServer = server.createMultiplexServer;
 
-	var web_server = __webpack_require__(77);
+	var web_server = __webpack_require__(78);
 	exports.createWebServer = web_server.createWebServer;
 
 	exports.Int64 = __webpack_require__(32);
-	exports.Q = __webpack_require__(114);
+	exports.Q = __webpack_require__(115);
 
-	var mprocessor = __webpack_require__(113);
-	var mprotocol = __webpack_require__(115);
+	var mprocessor = __webpack_require__(114);
+	var mprotocol = __webpack_require__(116);
 	exports.Multiplexer = mprotocol.Multiplexer;
 	exports.MultiplexedProcessor = mprocessor.MultiplexedProcessor;
 
@@ -12484,11 +12494,11 @@
 	 * Export transport and protocol so they can be used outside of a
 	 * cassandra/server context
 	 */
-	exports.TFramedTransport = __webpack_require__(69);
+	exports.TFramedTransport = __webpack_require__(70);
 	exports.TBufferedTransport = __webpack_require__(23);
 	exports.TBinaryProtocol = __webpack_require__(30);
-	exports.TJSONProtocol = __webpack_require__(72);
-	exports.TCompactProtocol = __webpack_require__(71);
+	exports.TJSONProtocol = __webpack_require__(73);
+	exports.TCompactProtocol = __webpack_require__(72);
 
 
 /***/ }),
@@ -16242,22 +16252,22 @@
 
 	function byteLength (b64) {
 	  // base64 is 4/3 + up to two characters of the original data
-	  return b64.length * 3 / 4 - placeHoldersCount(b64)
+	  return (b64.length * 3 / 4) - placeHoldersCount(b64)
 	}
 
 	function toByteArray (b64) {
-	  var i, j, l, tmp, placeHolders, arr
+	  var i, l, tmp, placeHolders, arr
 	  var len = b64.length
 	  placeHolders = placeHoldersCount(b64)
 
-	  arr = new Arr(len * 3 / 4 - placeHolders)
+	  arr = new Arr((len * 3 / 4) - placeHolders)
 
 	  // if there are placeholders, only get up to the last complete 4 chars
 	  l = placeHolders > 0 ? len - 4 : len
 
 	  var L = 0
 
-	  for (i = 0, j = 0; i < l; i += 4, j += 3) {
+	  for (i = 0; i < l; i += 4) {
 	    tmp = (revLookup[b64.charCodeAt(i)] << 18) | (revLookup[b64.charCodeAt(i + 1)] << 12) | (revLookup[b64.charCodeAt(i + 2)] << 6) | revLookup[b64.charCodeAt(i + 3)]
 	    arr[L++] = (tmp >> 16) & 0xFF
 	    arr[L++] = (tmp >> 8) & 0xFF
@@ -17364,7 +17374,7 @@
 	 */
 	var util = __webpack_require__(16);
 	var http = __webpack_require__(35);
-	var https = __webpack_require__(65);
+	var https = __webpack_require__(66);
 	var EventEmitter = __webpack_require__(21).EventEmitter;
 	var thrift = __webpack_require__(15);
 
@@ -17590,9 +17600,9 @@
 /***/ (function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(global) {var ClientRequest = __webpack_require__(36)
-	var extend = __webpack_require__(57)
-	var statusCodes = __webpack_require__(58)
-	var url = __webpack_require__(59)
+	var extend = __webpack_require__(58)
+	var statusCodes = __webpack_require__(59)
+	var url = __webpack_require__(60)
 
 	var http = exports
 
@@ -17678,7 +17688,7 @@
 	var inherits = __webpack_require__(38)
 	var response = __webpack_require__(39)
 	var stream = __webpack_require__(40)
-	var toArrayBuffer = __webpack_require__(56)
+	var toArrayBuffer = __webpack_require__(57)
 
 	var IncomingMessage = response.IncomingMessage
 	var rStates = response.readyStates
@@ -18284,23 +18294,45 @@
 	exports = module.exports = __webpack_require__(41);
 	exports.Stream = exports;
 	exports.Readable = exports;
-	exports.Writable = __webpack_require__(49);
-	exports.Duplex = __webpack_require__(48);
-	exports.Transform = __webpack_require__(54);
-	exports.PassThrough = __webpack_require__(55);
+	exports.Writable = __webpack_require__(50);
+	exports.Duplex = __webpack_require__(49);
+	exports.Transform = __webpack_require__(55);
+	exports.PassThrough = __webpack_require__(56);
 
 
 /***/ }),
 /* 41 */
 /***/ (function(module, exports, __webpack_require__) {
 
-	/* WEBPACK VAR INJECTION */(function(process) {'use strict';
+	/* WEBPACK VAR INJECTION */(function(process) {// Copyright Joyent, Inc. and other Node contributors.
+	//
+	// Permission is hereby granted, free of charge, to any person obtaining a
+	// copy of this software and associated documentation files (the
+	// "Software"), to deal in the Software without restriction, including
+	// without limitation the rights to use, copy, modify, merge, publish,
+	// distribute, sublicense, and/or sell copies of the Software, and to permit
+	// persons to whom the Software is furnished to do so, subject to the
+	// following conditions:
+	//
+	// The above copyright notice and this permission notice shall be included
+	// in all copies or substantial portions of the Software.
+	//
+	// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+	// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+	// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+	// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+	// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+	// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+	// USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-	module.exports = Readable;
+	'use strict';
 
 	/*<replacement>*/
+
 	var processNextTick = __webpack_require__(42);
 	/*</replacement>*/
+
+	module.exports = Readable;
 
 	/*<replacement>*/
 	var isArray = __webpack_require__(27);
@@ -18324,9 +18356,16 @@
 	var Stream = __webpack_require__(43);
 	/*</replacement>*/
 
-	var Buffer = __webpack_require__(24).Buffer;
+	// TODO(bmeurer): Change this back to const once hole checks are
+	// properly optimized away early in Ignition+TurboFan.
 	/*<replacement>*/
-	var bufferShim = __webpack_require__(44);
+	var Buffer = __webpack_require__(44).Buffer;
+	function _uint8ArrayToBuffer(chunk) {
+	  return Buffer.from(chunk);
+	}
+	function _isUint8Array(obj) {
+	  return Object.prototype.toString.call(obj) === '[object Uint8Array]' || Buffer.isBuffer(obj);
+	}
 	/*</replacement>*/
 
 	/*<replacement>*/
@@ -18345,6 +18384,7 @@
 	/*</replacement>*/
 
 	var BufferList = __webpack_require__(47);
+	var destroyImpl = __webpack_require__(48);
 	var StringDecoder;
 
 	util.inherits(Readable, Stream);
@@ -18366,7 +18406,7 @@
 	}
 
 	function ReadableState(options, stream) {
-	  Duplex = Duplex || __webpack_require__(48);
+	  Duplex = Duplex || __webpack_require__(49);
 
 	  options = options || {};
 
@@ -18383,7 +18423,7 @@
 	  this.highWaterMark = hwm || hwm === 0 ? hwm : defaultHwm;
 
 	  // cast to ints.
-	  this.highWaterMark = ~~this.highWaterMark;
+	  this.highWaterMark = Math.floor(this.highWaterMark);
 
 	  // A linked list is used to store data chunks instead of an array because the
 	  // linked list can remove elements from the beginning faster than
@@ -18397,10 +18437,10 @@
 	  this.endEmitted = false;
 	  this.reading = false;
 
-	  // a flag to be able to tell if the onwrite cb is called immediately,
-	  // or on a later tick.  We set this to true at first, because any
-	  // actions that shouldn't happen until "later" should generally also
-	  // not happen before the first write call.
+	  // a flag to be able to tell if the event 'readable'/'data' is emitted
+	  // immediately, or on a later tick.  We set this to true at first, because
+	  // any actions that shouldn't happen until "later" should generally also
+	  // not happen before the first read call.
 	  this.sync = true;
 
 	  // whenever we return null, then we set a flag to say
@@ -18410,14 +18450,13 @@
 	  this.readableListening = false;
 	  this.resumeScheduled = false;
 
+	  // has it been destroyed
+	  this.destroyed = false;
+
 	  // Crypto is kind of old and crusty.  Historically, its default string
 	  // encoding is 'binary' so we have to make this configurable.
 	  // Everything else in the universe uses 'utf8', though.
 	  this.defaultEncoding = options.defaultEncoding || 'utf8';
-
-	  // when piping, we only care about 'readable' events that happen
-	  // after read()ing all the bytes and not getting any pushback.
-	  this.ranOut = false;
 
 	  // the number of writers that are awaiting a drain event in .pipe()s
 	  this.awaitDrain = 0;
@@ -18428,14 +18467,14 @@
 	  this.decoder = null;
 	  this.encoding = null;
 	  if (options.encoding) {
-	    if (!StringDecoder) StringDecoder = __webpack_require__(53).StringDecoder;
+	    if (!StringDecoder) StringDecoder = __webpack_require__(54).StringDecoder;
 	    this.decoder = new StringDecoder(options.encoding);
 	    this.encoding = options.encoding;
 	  }
 	}
 
 	function Readable(options) {
-	  Duplex = Duplex || __webpack_require__(48);
+	  Duplex = Duplex || __webpack_require__(49);
 
 	  if (!(this instanceof Readable)) return new Readable(options);
 
@@ -18444,10 +18483,41 @@
 	  // legacy
 	  this.readable = true;
 
-	  if (options && typeof options.read === 'function') this._read = options.read;
+	  if (options) {
+	    if (typeof options.read === 'function') this._read = options.read;
+
+	    if (typeof options.destroy === 'function') this._destroy = options.destroy;
+	  }
 
 	  Stream.call(this);
 	}
+
+	Object.defineProperty(Readable.prototype, 'destroyed', {
+	  get: function () {
+	    if (this._readableState === undefined) {
+	      return false;
+	    }
+	    return this._readableState.destroyed;
+	  },
+	  set: function (value) {
+	    // we ignore the value if the stream
+	    // has not been initialized yet
+	    if (!this._readableState) {
+	      return;
+	    }
+
+	    // backward compatibility, the user is explicitly
+	    // managing destroyed
+	    this._readableState.destroyed = value;
+	  }
+	});
+
+	Readable.prototype.destroy = destroyImpl.destroy;
+	Readable.prototype._undestroy = destroyImpl.undestroy;
+	Readable.prototype._destroy = function (err, cb) {
+	  this.push(null);
+	  cb(err);
+	};
 
 	// Manually shove something into the read() buffer.
 	// This returns true if the highWaterMark has not been hit yet,
@@ -18455,74 +18525,85 @@
 	// write() some more.
 	Readable.prototype.push = function (chunk, encoding) {
 	  var state = this._readableState;
+	  var skipChunkCheck;
 
-	  if (!state.objectMode && typeof chunk === 'string') {
-	    encoding = encoding || state.defaultEncoding;
-	    if (encoding !== state.encoding) {
-	      chunk = bufferShim.from(chunk, encoding);
-	      encoding = '';
+	  if (!state.objectMode) {
+	    if (typeof chunk === 'string') {
+	      encoding = encoding || state.defaultEncoding;
+	      if (encoding !== state.encoding) {
+	        chunk = Buffer.from(chunk, encoding);
+	        encoding = '';
+	      }
+	      skipChunkCheck = true;
 	    }
+	  } else {
+	    skipChunkCheck = true;
 	  }
 
-	  return readableAddChunk(this, state, chunk, encoding, false);
+	  return readableAddChunk(this, chunk, encoding, false, skipChunkCheck);
 	};
 
 	// Unshift should *always* be something directly out of read()
 	Readable.prototype.unshift = function (chunk) {
-	  var state = this._readableState;
-	  return readableAddChunk(this, state, chunk, '', true);
+	  return readableAddChunk(this, chunk, null, true, false);
 	};
 
-	Readable.prototype.isPaused = function () {
-	  return this._readableState.flowing === false;
-	};
-
-	function readableAddChunk(stream, state, chunk, encoding, addToFront) {
-	  var er = chunkInvalid(state, chunk);
-	  if (er) {
-	    stream.emit('error', er);
-	  } else if (chunk === null) {
+	function readableAddChunk(stream, chunk, encoding, addToFront, skipChunkCheck) {
+	  var state = stream._readableState;
+	  if (chunk === null) {
 	    state.reading = false;
 	    onEofChunk(stream, state);
-	  } else if (state.objectMode || chunk && chunk.length > 0) {
-	    if (state.ended && !addToFront) {
-	      var e = new Error('stream.push() after EOF');
-	      stream.emit('error', e);
-	    } else if (state.endEmitted && addToFront) {
-	      var _e = new Error('stream.unshift() after end event');
-	      stream.emit('error', _e);
-	    } else {
-	      var skipAdd;
-	      if (state.decoder && !addToFront && !encoding) {
-	        chunk = state.decoder.write(chunk);
-	        skipAdd = !state.objectMode && chunk.length === 0;
+	  } else {
+	    var er;
+	    if (!skipChunkCheck) er = chunkInvalid(state, chunk);
+	    if (er) {
+	      stream.emit('error', er);
+	    } else if (state.objectMode || chunk && chunk.length > 0) {
+	      if (typeof chunk !== 'string' && Object.getPrototypeOf(chunk) !== Buffer.prototype && !state.objectMode) {
+	        chunk = _uint8ArrayToBuffer(chunk);
 	      }
 
-	      if (!addToFront) state.reading = false;
-
-	      // Don't add to the buffer if we've decoded to an empty string chunk and
-	      // we're not in object mode
-	      if (!skipAdd) {
-	        // if we want the data now, just emit it.
-	        if (state.flowing && state.length === 0 && !state.sync) {
-	          stream.emit('data', chunk);
-	          stream.read(0);
+	      if (addToFront) {
+	        if (state.endEmitted) stream.emit('error', new Error('stream.unshift() after end event'));else addChunk(stream, state, chunk, true);
+	      } else if (state.ended) {
+	        stream.emit('error', new Error('stream.push() after EOF'));
+	      } else {
+	        state.reading = false;
+	        if (state.decoder && !encoding) {
+	          chunk = state.decoder.write(chunk);
+	          if (state.objectMode || chunk.length !== 0) addChunk(stream, state, chunk, false);else maybeReadMore(stream, state);
 	        } else {
-	          // update the buffer info.
-	          state.length += state.objectMode ? 1 : chunk.length;
-	          if (addToFront) state.buffer.unshift(chunk);else state.buffer.push(chunk);
-
-	          if (state.needReadable) emitReadable(stream);
+	          addChunk(stream, state, chunk, false);
 	        }
 	      }
-
-	      maybeReadMore(stream, state);
+	    } else if (!addToFront) {
+	      state.reading = false;
 	    }
-	  } else if (!addToFront) {
-	    state.reading = false;
 	  }
 
 	  return needMoreData(state);
+	}
+
+	function addChunk(stream, state, chunk, addToFront) {
+	  if (state.flowing && state.length === 0 && !state.sync) {
+	    stream.emit('data', chunk);
+	    stream.read(0);
+	  } else {
+	    // update the buffer info.
+	    state.length += state.objectMode ? 1 : chunk.length;
+	    if (addToFront) state.buffer.unshift(chunk);else state.buffer.push(chunk);
+
+	    if (state.needReadable) emitReadable(stream);
+	  }
+	  maybeReadMore(stream, state);
+	}
+
+	function chunkInvalid(state, chunk) {
+	  var er;
+	  if (!_isUint8Array(chunk) && typeof chunk !== 'string' && chunk !== undefined && !state.objectMode) {
+	    er = new TypeError('Invalid non-string/buffer chunk');
+	  }
+	  return er;
 	}
 
 	// if it's past the high water mark, we can push in some more.
@@ -18536,9 +18617,13 @@
 	  return !state.ended && (state.needReadable || state.length < state.highWaterMark || state.length === 0);
 	}
 
+	Readable.prototype.isPaused = function () {
+	  return this._readableState.flowing === false;
+	};
+
 	// backwards compatibility.
 	Readable.prototype.setEncoding = function (enc) {
-	  if (!StringDecoder) StringDecoder = __webpack_require__(53).StringDecoder;
+	  if (!StringDecoder) StringDecoder = __webpack_require__(54).StringDecoder;
 	  this._readableState.decoder = new StringDecoder(enc);
 	  this._readableState.encoding = enc;
 	  return this;
@@ -18684,14 +18769,6 @@
 	  return ret;
 	};
 
-	function chunkInvalid(state, chunk) {
-	  var er = null;
-	  if (!Buffer.isBuffer(chunk) && typeof chunk !== 'string' && chunk !== null && chunk !== undefined && !state.objectMode) {
-	    er = new TypeError('Invalid non-string/buffer chunk');
-	  }
-	  return er;
-	}
-
 	function onEofChunk(stream, state) {
 	  if (state.ended) return;
 	  if (state.decoder) {
@@ -18779,14 +18856,17 @@
 
 	  var doEnd = (!pipeOpts || pipeOpts.end !== false) && dest !== process.stdout && dest !== process.stderr;
 
-	  var endFn = doEnd ? onend : cleanup;
+	  var endFn = doEnd ? onend : unpipe;
 	  if (state.endEmitted) processNextTick(endFn);else src.once('end', endFn);
 
 	  dest.on('unpipe', onunpipe);
-	  function onunpipe(readable) {
+	  function onunpipe(readable, unpipeInfo) {
 	    debug('onunpipe');
 	    if (readable === src) {
-	      cleanup();
+	      if (unpipeInfo && unpipeInfo.hasUnpiped === false) {
+	        unpipeInfo.hasUnpiped = true;
+	        cleanup();
+	      }
 	    }
 	  }
 
@@ -18812,7 +18892,7 @@
 	    dest.removeListener('error', onerror);
 	    dest.removeListener('unpipe', onunpipe);
 	    src.removeListener('end', onend);
-	    src.removeListener('end', cleanup);
+	    src.removeListener('end', unpipe);
 	    src.removeListener('data', ondata);
 
 	    cleanedUp = true;
@@ -18905,6 +18985,7 @@
 
 	Readable.prototype.unpipe = function (dest) {
 	  var state = this._readableState;
+	  var unpipeInfo = { hasUnpiped: false };
 
 	  // if we're not piping anywhere, then do nothing.
 	  if (state.pipesCount === 0) return this;
@@ -18920,7 +19001,7 @@
 	    state.pipes = null;
 	    state.pipesCount = 0;
 	    state.flowing = false;
-	    if (dest) dest.emit('unpipe', this);
+	    if (dest) dest.emit('unpipe', this, unpipeInfo);
 	    return this;
 	  }
 
@@ -18935,7 +19016,7 @@
 	    state.flowing = false;
 
 	    for (var i = 0; i < len; i++) {
-	      dests[i].emit('unpipe', this);
+	      dests[i].emit('unpipe', this, unpipeInfo);
 	    }return this;
 	  }
 
@@ -18947,7 +19028,7 @@
 	  state.pipesCount -= 1;
 	  if (state.pipesCount === 1) state.pipes = state.pipes[0];
 
-	  dest.emit('unpipe', this);
+	  dest.emit('unpipe', this, unpipeInfo);
 
 	  return this;
 	};
@@ -18968,7 +19049,7 @@
 	      if (!state.reading) {
 	        processNextTick(nReadingNextTick, this);
 	      } else if (state.length) {
-	        emitReadable(this, state);
+	        emitReadable(this);
 	      }
 	    }
 	  }
@@ -19169,7 +19250,7 @@
 	// This function is designed to be inlinable, so please take care when making
 	// changes to the function body.
 	function copyFromBuffer(n, list) {
-	  var ret = bufferShim.allocUnsafe(n);
+	  var ret = Buffer.allocUnsafe(n);
 	  var p = list.head;
 	  var c = 1;
 	  p.data.copy(ret);
@@ -19292,116 +19373,69 @@
 /* 44 */
 /***/ (function(module, exports, __webpack_require__) {
 
-	/* WEBPACK VAR INJECTION */(function(global) {'use strict';
+	/* eslint-disable node/no-deprecated-api */
+	var buffer = __webpack_require__(24)
+	var Buffer = buffer.Buffer
 
-	var buffer = __webpack_require__(24);
-	var Buffer = buffer.Buffer;
-	var SlowBuffer = buffer.SlowBuffer;
-	var MAX_LEN = buffer.kMaxLength || 2147483647;
-	exports.alloc = function alloc(size, fill, encoding) {
-	  if (typeof Buffer.alloc === 'function') {
-	    return Buffer.alloc(size, fill, encoding);
+	// alternative to using Object.keys for old browsers
+	function copyProps (src, dst) {
+	  for (var key in src) {
+	    dst[key] = src[key]
 	  }
-	  if (typeof encoding === 'number') {
-	    throw new TypeError('encoding must not be number');
+	}
+	if (Buffer.from && Buffer.alloc && Buffer.allocUnsafe && Buffer.allocUnsafeSlow) {
+	  module.exports = buffer
+	} else {
+	  // Copy properties from require('buffer')
+	  copyProps(buffer, exports)
+	  exports.Buffer = SafeBuffer
+	}
+
+	function SafeBuffer (arg, encodingOrOffset, length) {
+	  return Buffer(arg, encodingOrOffset, length)
+	}
+
+	// Copy static methods from Buffer
+	copyProps(Buffer, SafeBuffer)
+
+	SafeBuffer.from = function (arg, encodingOrOffset, length) {
+	  if (typeof arg === 'number') {
+	    throw new TypeError('Argument must not be a number')
 	  }
+	  return Buffer(arg, encodingOrOffset, length)
+	}
+
+	SafeBuffer.alloc = function (size, fill, encoding) {
 	  if (typeof size !== 'number') {
-	    throw new TypeError('size must be a number');
+	    throw new TypeError('Argument must be a number')
 	  }
-	  if (size > MAX_LEN) {
-	    throw new RangeError('size is too large');
-	  }
-	  var enc = encoding;
-	  var _fill = fill;
-	  if (_fill === undefined) {
-	    enc = undefined;
-	    _fill = 0;
-	  }
-	  var buf = new Buffer(size);
-	  if (typeof _fill === 'string') {
-	    var fillBuf = new Buffer(_fill, enc);
-	    var flen = fillBuf.length;
-	    var i = -1;
-	    while (++i < size) {
-	      buf[i] = fillBuf[i % flen];
+	  var buf = Buffer(size)
+	  if (fill !== undefined) {
+	    if (typeof encoding === 'string') {
+	      buf.fill(fill, encoding)
+	    } else {
+	      buf.fill(fill)
 	    }
 	  } else {
-	    buf.fill(_fill);
+	    buf.fill(0)
 	  }
-	  return buf;
-	}
-	exports.allocUnsafe = function allocUnsafe(size) {
-	  if (typeof Buffer.allocUnsafe === 'function') {
-	    return Buffer.allocUnsafe(size);
-	  }
-	  if (typeof size !== 'number') {
-	    throw new TypeError('size must be a number');
-	  }
-	  if (size > MAX_LEN) {
-	    throw new RangeError('size is too large');
-	  }
-	  return new Buffer(size);
-	}
-	exports.from = function from(value, encodingOrOffset, length) {
-	  if (typeof Buffer.from === 'function' && (!global.Uint8Array || Uint8Array.from !== Buffer.from)) {
-	    return Buffer.from(value, encodingOrOffset, length);
-	  }
-	  if (typeof value === 'number') {
-	    throw new TypeError('"value" argument must not be a number');
-	  }
-	  if (typeof value === 'string') {
-	    return new Buffer(value, encodingOrOffset);
-	  }
-	  if (typeof ArrayBuffer !== 'undefined' && value instanceof ArrayBuffer) {
-	    var offset = encodingOrOffset;
-	    if (arguments.length === 1) {
-	      return new Buffer(value);
-	    }
-	    if (typeof offset === 'undefined') {
-	      offset = 0;
-	    }
-	    var len = length;
-	    if (typeof len === 'undefined') {
-	      len = value.byteLength - offset;
-	    }
-	    if (offset >= value.byteLength) {
-	      throw new RangeError('\'offset\' is out of bounds');
-	    }
-	    if (len > value.byteLength - offset) {
-	      throw new RangeError('\'length\' is out of bounds');
-	    }
-	    return new Buffer(value.slice(offset, offset + len));
-	  }
-	  if (Buffer.isBuffer(value)) {
-	    var out = new Buffer(value.length);
-	    value.copy(out, 0, 0, value.length);
-	    return out;
-	  }
-	  if (value) {
-	    if (Array.isArray(value) || (typeof ArrayBuffer !== 'undefined' && value.buffer instanceof ArrayBuffer) || 'length' in value) {
-	      return new Buffer(value);
-	    }
-	    if (value.type === 'Buffer' && Array.isArray(value.data)) {
-	      return new Buffer(value.data);
-	    }
-	  }
-
-	  throw new TypeError('First argument must be a string, Buffer, ' + 'ArrayBuffer, Array, or array-like object.');
-	}
-	exports.allocUnsafeSlow = function allocUnsafeSlow(size) {
-	  if (typeof Buffer.allocUnsafeSlow === 'function') {
-	    return Buffer.allocUnsafeSlow(size);
-	  }
-	  if (typeof size !== 'number') {
-	    throw new TypeError('size must be a number');
-	  }
-	  if (size >= MAX_LEN) {
-	    throw new RangeError('size is too large');
-	  }
-	  return new SlowBuffer(size);
+	  return buf
 	}
 
-	/* WEBPACK VAR INJECTION */}.call(exports, (function() { return this; }())))
+	SafeBuffer.allocUnsafe = function (size) {
+	  if (typeof size !== 'number') {
+	    throw new TypeError('Argument must be a number')
+	  }
+	  return Buffer(size)
+	}
+
+	SafeBuffer.allocUnsafeSlow = function (size) {
+	  if (typeof size !== 'number') {
+	    throw new TypeError('Argument must be a number')
+	  }
+	  return buffer.SlowBuffer(size)
+	}
+
 
 /***/ }),
 /* 45 */
@@ -19529,72 +19563,180 @@
 
 	'use strict';
 
-	var Buffer = __webpack_require__(24).Buffer;
 	/*<replacement>*/
-	var bufferShim = __webpack_require__(44);
+
+	function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+	var Buffer = __webpack_require__(44).Buffer;
 	/*</replacement>*/
 
-	module.exports = BufferList;
-
-	function BufferList() {
-	  this.head = null;
-	  this.tail = null;
-	  this.length = 0;
+	function copyBuffer(src, target, offset) {
+	  src.copy(target, offset);
 	}
 
-	BufferList.prototype.push = function (v) {
-	  var entry = { data: v, next: null };
-	  if (this.length > 0) this.tail.next = entry;else this.head = entry;
-	  this.tail = entry;
-	  ++this.length;
-	};
+	module.exports = function () {
+	  function BufferList() {
+	    _classCallCheck(this, BufferList);
 
-	BufferList.prototype.unshift = function (v) {
-	  var entry = { data: v, next: this.head };
-	  if (this.length === 0) this.tail = entry;
-	  this.head = entry;
-	  ++this.length;
-	};
-
-	BufferList.prototype.shift = function () {
-	  if (this.length === 0) return;
-	  var ret = this.head.data;
-	  if (this.length === 1) this.head = this.tail = null;else this.head = this.head.next;
-	  --this.length;
-	  return ret;
-	};
-
-	BufferList.prototype.clear = function () {
-	  this.head = this.tail = null;
-	  this.length = 0;
-	};
-
-	BufferList.prototype.join = function (s) {
-	  if (this.length === 0) return '';
-	  var p = this.head;
-	  var ret = '' + p.data;
-	  while (p = p.next) {
-	    ret += s + p.data;
-	  }return ret;
-	};
-
-	BufferList.prototype.concat = function (n) {
-	  if (this.length === 0) return bufferShim.alloc(0);
-	  if (this.length === 1) return this.head.data;
-	  var ret = bufferShim.allocUnsafe(n >>> 0);
-	  var p = this.head;
-	  var i = 0;
-	  while (p) {
-	    p.data.copy(ret, i);
-	    i += p.data.length;
-	    p = p.next;
+	    this.head = null;
+	    this.tail = null;
+	    this.length = 0;
 	  }
-	  return ret;
-	};
+
+	  BufferList.prototype.push = function push(v) {
+	    var entry = { data: v, next: null };
+	    if (this.length > 0) this.tail.next = entry;else this.head = entry;
+	    this.tail = entry;
+	    ++this.length;
+	  };
+
+	  BufferList.prototype.unshift = function unshift(v) {
+	    var entry = { data: v, next: this.head };
+	    if (this.length === 0) this.tail = entry;
+	    this.head = entry;
+	    ++this.length;
+	  };
+
+	  BufferList.prototype.shift = function shift() {
+	    if (this.length === 0) return;
+	    var ret = this.head.data;
+	    if (this.length === 1) this.head = this.tail = null;else this.head = this.head.next;
+	    --this.length;
+	    return ret;
+	  };
+
+	  BufferList.prototype.clear = function clear() {
+	    this.head = this.tail = null;
+	    this.length = 0;
+	  };
+
+	  BufferList.prototype.join = function join(s) {
+	    if (this.length === 0) return '';
+	    var p = this.head;
+	    var ret = '' + p.data;
+	    while (p = p.next) {
+	      ret += s + p.data;
+	    }return ret;
+	  };
+
+	  BufferList.prototype.concat = function concat(n) {
+	    if (this.length === 0) return Buffer.alloc(0);
+	    if (this.length === 1) return this.head.data;
+	    var ret = Buffer.allocUnsafe(n >>> 0);
+	    var p = this.head;
+	    var i = 0;
+	    while (p) {
+	      copyBuffer(p.data, ret, i);
+	      i += p.data.length;
+	      p = p.next;
+	    }
+	    return ret;
+	  };
+
+	  return BufferList;
+	}();
 
 /***/ }),
 /* 48 */
 /***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	/*<replacement>*/
+
+	var processNextTick = __webpack_require__(42);
+	/*</replacement>*/
+
+	// undocumented cb() API, needed for core, not for public API
+	function destroy(err, cb) {
+	  var _this = this;
+
+	  var readableDestroyed = this._readableState && this._readableState.destroyed;
+	  var writableDestroyed = this._writableState && this._writableState.destroyed;
+
+	  if (readableDestroyed || writableDestroyed) {
+	    if (cb) {
+	      cb(err);
+	    } else if (err && (!this._writableState || !this._writableState.errorEmitted)) {
+	      processNextTick(emitErrorNT, this, err);
+	    }
+	    return;
+	  }
+
+	  // we set destroyed to true before firing error callbacks in order
+	  // to make it re-entrance safe in case destroy() is called within callbacks
+
+	  if (this._readableState) {
+	    this._readableState.destroyed = true;
+	  }
+
+	  // if this is a duplex stream mark the writable part as destroyed as well
+	  if (this._writableState) {
+	    this._writableState.destroyed = true;
+	  }
+
+	  this._destroy(err || null, function (err) {
+	    if (!cb && err) {
+	      processNextTick(emitErrorNT, _this, err);
+	      if (_this._writableState) {
+	        _this._writableState.errorEmitted = true;
+	      }
+	    } else if (cb) {
+	      cb(err);
+	    }
+	  });
+	}
+
+	function undestroy() {
+	  if (this._readableState) {
+	    this._readableState.destroyed = false;
+	    this._readableState.reading = false;
+	    this._readableState.ended = false;
+	    this._readableState.endEmitted = false;
+	  }
+
+	  if (this._writableState) {
+	    this._writableState.destroyed = false;
+	    this._writableState.ended = false;
+	    this._writableState.ending = false;
+	    this._writableState.finished = false;
+	    this._writableState.errorEmitted = false;
+	  }
+	}
+
+	function emitErrorNT(self, err) {
+	  self.emit('error', err);
+	}
+
+	module.exports = {
+	  destroy: destroy,
+	  undestroy: undestroy
+	};
+
+/***/ }),
+/* 49 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	// Copyright Joyent, Inc. and other Node contributors.
+	//
+	// Permission is hereby granted, free of charge, to any person obtaining a
+	// copy of this software and associated documentation files (the
+	// "Software"), to deal in the Software without restriction, including
+	// without limitation the rights to use, copy, modify, merge, publish,
+	// distribute, sublicense, and/or sell copies of the Software, and to permit
+	// persons to whom the Software is furnished to do so, subject to the
+	// following conditions:
+	//
+	// The above copyright notice and this permission notice shall be included
+	// in all copies or substantial portions of the Software.
+	//
+	// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+	// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+	// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+	// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+	// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+	// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+	// USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 	// a duplex stream is just a stream that is both readable and writable.
 	// Since JS doesn't have multiple prototypal inheritance, this class
@@ -19605,6 +19747,10 @@
 
 	/*<replacement>*/
 
+	var processNextTick = __webpack_require__(42);
+	/*</replacement>*/
+
+	/*<replacement>*/
 	var objectKeys = Object.keys || function (obj) {
 	  var keys = [];
 	  for (var key in obj) {
@@ -19616,16 +19762,12 @@
 	module.exports = Duplex;
 
 	/*<replacement>*/
-	var processNextTick = __webpack_require__(42);
-	/*</replacement>*/
-
-	/*<replacement>*/
 	var util = __webpack_require__(45);
 	util.inherits = __webpack_require__(38);
 	/*</replacement>*/
 
 	var Readable = __webpack_require__(41);
-	var Writable = __webpack_require__(49);
+	var Writable = __webpack_require__(50);
 
 	util.inherits(Duplex, Readable);
 
@@ -19666,6 +19808,34 @@
 	  self.end();
 	}
 
+	Object.defineProperty(Duplex.prototype, 'destroyed', {
+	  get: function () {
+	    if (this._readableState === undefined || this._writableState === undefined) {
+	      return false;
+	    }
+	    return this._readableState.destroyed && this._writableState.destroyed;
+	  },
+	  set: function (value) {
+	    // we ignore the value if the stream
+	    // has not been initialized yet
+	    if (this._readableState === undefined || this._writableState === undefined) {
+	      return;
+	    }
+
+	    // backward compatibility, the user is explicitly
+	    // managing destroyed
+	    this._readableState.destroyed = value;
+	    this._writableState.destroyed = value;
+	  }
+	});
+
+	Duplex.prototype._destroy = function (err, cb) {
+	  this.push(null);
+	  this.end();
+
+	  processNextTick(cb, err);
+	};
+
 	function forEach(xs, f) {
 	  for (var i = 0, l = xs.length; i < l; i++) {
 	    f(xs[i], i);
@@ -19673,20 +19843,63 @@
 	}
 
 /***/ }),
-/* 49 */
+/* 50 */
 /***/ (function(module, exports, __webpack_require__) {
 
-	/* WEBPACK VAR INJECTION */(function(process, setImmediate) {// A bit simpler than readable streams.
+	/* WEBPACK VAR INJECTION */(function(process, setImmediate) {// Copyright Joyent, Inc. and other Node contributors.
+	//
+	// Permission is hereby granted, free of charge, to any person obtaining a
+	// copy of this software and associated documentation files (the
+	// "Software"), to deal in the Software without restriction, including
+	// without limitation the rights to use, copy, modify, merge, publish,
+	// distribute, sublicense, and/or sell copies of the Software, and to permit
+	// persons to whom the Software is furnished to do so, subject to the
+	// following conditions:
+	//
+	// The above copyright notice and this permission notice shall be included
+	// in all copies or substantial portions of the Software.
+	//
+	// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+	// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+	// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+	// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+	// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+	// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+	// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+	// A bit simpler than readable streams.
 	// Implement an async ._write(chunk, encoding, cb), and it'll handle all
 	// the drain event emission and buffering.
 
 	'use strict';
 
-	module.exports = Writable;
-
 	/*<replacement>*/
+
 	var processNextTick = __webpack_require__(42);
 	/*</replacement>*/
+
+	module.exports = Writable;
+
+	/* <replacement> */
+	function WriteReq(chunk, encoding, cb) {
+	  this.chunk = chunk;
+	  this.encoding = encoding;
+	  this.callback = cb;
+	  this.next = null;
+	}
+
+	// It seems a linked list but it is not
+	// there will be only 2 of these for each stream
+	function CorkedRequest(state) {
+	  var _this = this;
+
+	  this.next = null;
+	  this.entry = null;
+	  this.finish = function () {
+	    onCorkedFinish(_this, state);
+	  };
+	}
+	/* </replacement> */
 
 	/*<replacement>*/
 	var asyncWrite = !process.browser && ['v0.10', 'v0.9.'].indexOf(process.version.slice(0, 5)) > -1 ? setImmediate : processNextTick;
@@ -19705,7 +19918,7 @@
 
 	/*<replacement>*/
 	var internalUtil = {
-	  deprecate: __webpack_require__(52)
+	  deprecate: __webpack_require__(53)
 	};
 	/*</replacement>*/
 
@@ -19713,24 +19926,24 @@
 	var Stream = __webpack_require__(43);
 	/*</replacement>*/
 
-	var Buffer = __webpack_require__(24).Buffer;
 	/*<replacement>*/
-	var bufferShim = __webpack_require__(44);
+	var Buffer = __webpack_require__(44).Buffer;
+	function _uint8ArrayToBuffer(chunk) {
+	  return Buffer.from(chunk);
+	}
+	function _isUint8Array(obj) {
+	  return Object.prototype.toString.call(obj) === '[object Uint8Array]' || Buffer.isBuffer(obj);
+	}
 	/*</replacement>*/
+
+	var destroyImpl = __webpack_require__(48);
 
 	util.inherits(Writable, Stream);
 
 	function nop() {}
 
-	function WriteReq(chunk, encoding, cb) {
-	  this.chunk = chunk;
-	  this.encoding = encoding;
-	  this.callback = cb;
-	  this.next = null;
-	}
-
 	function WritableState(options, stream) {
-	  Duplex = Duplex || __webpack_require__(48);
+	  Duplex = Duplex || __webpack_require__(49);
 
 	  options = options || {};
 
@@ -19748,7 +19961,10 @@
 	  this.highWaterMark = hwm || hwm === 0 ? hwm : defaultHwm;
 
 	  // cast to ints.
-	  this.highWaterMark = ~~this.highWaterMark;
+	  this.highWaterMark = Math.floor(this.highWaterMark);
+
+	  // if _final has been called
+	  this.finalCalled = false;
 
 	  // drain event flag.
 	  this.needDrain = false;
@@ -19758,6 +19974,9 @@
 	  this.ended = false;
 	  // when 'finish' is emitted
 	  this.finished = false;
+
+	  // has it been destroyed
+	  this.destroyed = false;
 
 	  // should we decode strings into buffers before passing to _write?
 	  // this is here so that some node-core streams can optimize string
@@ -19840,7 +20059,7 @@
 	    Object.defineProperty(WritableState.prototype, 'buffer', {
 	      get: internalUtil.deprecate(function () {
 	        return this.getBuffer();
-	      }, '_writableState.buffer is deprecated. Use _writableState.getBuffer ' + 'instead.')
+	      }, '_writableState.buffer is deprecated. Use _writableState.getBuffer ' + 'instead.', 'DEP0003')
 	    });
 	  } catch (_) {}
 	})();
@@ -19864,7 +20083,7 @@
 	}
 
 	function Writable(options) {
-	  Duplex = Duplex || __webpack_require__(48);
+	  Duplex = Duplex || __webpack_require__(49);
 
 	  // Writable ctor is applied to Duplexes, too.
 	  // `realHasInstance` is necessary because using plain `instanceof`
@@ -19886,6 +20105,10 @@
 	    if (typeof options.write === 'function') this._write = options.write;
 
 	    if (typeof options.writev === 'function') this._writev = options.writev;
+
+	    if (typeof options.destroy === 'function') this._destroy = options.destroy;
+
+	    if (typeof options.final === 'function') this._final = options.final;
 	  }
 
 	  Stream.call(this);
@@ -19926,7 +20149,11 @@
 	Writable.prototype.write = function (chunk, encoding, cb) {
 	  var state = this._writableState;
 	  var ret = false;
-	  var isBuf = Buffer.isBuffer(chunk);
+	  var isBuf = _isUint8Array(chunk) && !state.objectMode;
+
+	  if (isBuf && !Buffer.isBuffer(chunk)) {
+	    chunk = _uint8ArrayToBuffer(chunk);
+	  }
 
 	  if (typeof encoding === 'function') {
 	    cb = encoding;
@@ -19971,7 +20198,7 @@
 
 	function decodeChunk(state, chunk, encoding) {
 	  if (!state.objectMode && state.decodeStrings !== false && typeof chunk === 'string') {
-	    chunk = bufferShim.from(chunk, encoding);
+	    chunk = Buffer.from(chunk, encoding);
 	  }
 	  return chunk;
 	}
@@ -19981,8 +20208,12 @@
 	// If we return false, then we need a drain event, so set that flag.
 	function writeOrBuffer(stream, state, isBuf, chunk, encoding, cb) {
 	  if (!isBuf) {
-	    chunk = decodeChunk(state, chunk, encoding);
-	    if (Buffer.isBuffer(chunk)) encoding = 'buffer';
+	    var newChunk = decodeChunk(state, chunk, encoding);
+	    if (chunk !== newChunk) {
+	      isBuf = true;
+	      encoding = 'buffer';
+	      chunk = newChunk;
+	    }
 	  }
 	  var len = state.objectMode ? 1 : chunk.length;
 
@@ -19994,7 +20225,13 @@
 
 	  if (state.writing || state.corked) {
 	    var last = state.lastBufferedRequest;
-	    state.lastBufferedRequest = new WriteReq(chunk, encoding, cb);
+	    state.lastBufferedRequest = {
+	      chunk: chunk,
+	      encoding: encoding,
+	      isBuf: isBuf,
+	      callback: cb,
+	      next: null
+	    };
 	    if (last) {
 	      last.next = state.lastBufferedRequest;
 	    } else {
@@ -20019,10 +20256,26 @@
 
 	function onwriteError(stream, state, sync, er, cb) {
 	  --state.pendingcb;
-	  if (sync) processNextTick(cb, er);else cb(er);
 
-	  stream._writableState.errorEmitted = true;
-	  stream.emit('error', er);
+	  if (sync) {
+	    // defer the callback if we are being called synchronously
+	    // to avoid piling up things on the stack
+	    processNextTick(cb, er);
+	    // this can emit finish, and it will always happen
+	    // after error
+	    processNextTick(finishMaybe, stream, state);
+	    stream._writableState.errorEmitted = true;
+	    stream.emit('error', er);
+	  } else {
+	    // the caller expect this to happen before if
+	    // it is async
+	    cb(er);
+	    stream._writableState.errorEmitted = true;
+	    stream.emit('error', er);
+	    // this can emit finish, but finish must
+	    // always follow error
+	    finishMaybe(stream, state);
+	  }
 	}
 
 	function onwriteStateUpdate(state) {
@@ -20087,11 +20340,14 @@
 	    holder.entry = entry;
 
 	    var count = 0;
+	    var allBuffers = true;
 	    while (entry) {
 	      buffer[count] = entry;
+	      if (!entry.isBuf) allBuffers = false;
 	      entry = entry.next;
 	      count += 1;
 	    }
+	    buffer.allBuffers = allBuffers;
 
 	    doWrite(stream, state, true, state.length, buffer, '', holder.finish);
 
@@ -20165,23 +20421,37 @@
 	function needFinish(state) {
 	  return state.ending && state.length === 0 && state.bufferedRequest === null && !state.finished && !state.writing;
 	}
-
-	function prefinish(stream, state) {
-	  if (!state.prefinished) {
+	function callFinal(stream, state) {
+	  stream._final(function (err) {
+	    state.pendingcb--;
+	    if (err) {
+	      stream.emit('error', err);
+	    }
 	    state.prefinished = true;
 	    stream.emit('prefinish');
+	    finishMaybe(stream, state);
+	  });
+	}
+	function prefinish(stream, state) {
+	  if (!state.prefinished && !state.finalCalled) {
+	    if (typeof stream._final === 'function') {
+	      state.pendingcb++;
+	      state.finalCalled = true;
+	      processNextTick(callFinal, stream, state);
+	    } else {
+	      state.prefinished = true;
+	      stream.emit('prefinish');
+	    }
 	  }
 	}
 
 	function finishMaybe(stream, state) {
 	  var need = needFinish(state);
 	  if (need) {
+	    prefinish(stream, state);
 	    if (state.pendingcb === 0) {
-	      prefinish(stream, state);
 	      state.finished = true;
 	      stream.emit('finish');
-	    } else {
-	      prefinish(stream, state);
 	    }
 	  }
 	  return need;
@@ -20197,33 +20467,53 @@
 	  stream.writable = false;
 	}
 
-	// It seems a linked list but it is not
-	// there will be only 2 of these for each stream
-	function CorkedRequest(state) {
-	  var _this = this;
-
-	  this.next = null;
-	  this.entry = null;
-	  this.finish = function (err) {
-	    var entry = _this.entry;
-	    _this.entry = null;
-	    while (entry) {
-	      var cb = entry.callback;
-	      state.pendingcb--;
-	      cb(err);
-	      entry = entry.next;
-	    }
-	    if (state.corkedRequestsFree) {
-	      state.corkedRequestsFree.next = _this;
-	    } else {
-	      state.corkedRequestsFree = _this;
-	    }
-	  };
+	function onCorkedFinish(corkReq, state, err) {
+	  var entry = corkReq.entry;
+	  corkReq.entry = null;
+	  while (entry) {
+	    var cb = entry.callback;
+	    state.pendingcb--;
+	    cb(err);
+	    entry = entry.next;
+	  }
+	  if (state.corkedRequestsFree) {
+	    state.corkedRequestsFree.next = corkReq;
+	  } else {
+	    state.corkedRequestsFree = corkReq;
+	  }
 	}
-	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(17), __webpack_require__(50).setImmediate))
+
+	Object.defineProperty(Writable.prototype, 'destroyed', {
+	  get: function () {
+	    if (this._writableState === undefined) {
+	      return false;
+	    }
+	    return this._writableState.destroyed;
+	  },
+	  set: function (value) {
+	    // we ignore the value if the stream
+	    // has not been initialized yet
+	    if (!this._writableState) {
+	      return;
+	    }
+
+	    // backward compatibility, the user is explicitly
+	    // managing destroyed
+	    this._writableState.destroyed = value;
+	  }
+	});
+
+	Writable.prototype.destroy = destroyImpl.destroy;
+	Writable.prototype._undestroy = destroyImpl.undestroy;
+	Writable.prototype._destroy = function (err, cb) {
+	  this.end();
+	  cb(err);
+	};
+
+	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(17), __webpack_require__(51).setImmediate))
 
 /***/ }),
-/* 50 */
+/* 51 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	var apply = Function.prototype.apply;
@@ -20276,13 +20566,13 @@
 	};
 
 	// setimmediate attaches itself to the global object
-	__webpack_require__(51);
+	__webpack_require__(52);
 	exports.setImmediate = setImmediate;
 	exports.clearImmediate = clearImmediate;
 
 
 /***/ }),
-/* 51 */
+/* 52 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(global, process) {(function (global, undefined) {
@@ -20475,7 +20765,7 @@
 	/* WEBPACK VAR INJECTION */}.call(exports, (function() { return this; }()), __webpack_require__(17)))
 
 /***/ }),
-/* 52 */
+/* 53 */
 /***/ (function(module, exports) {
 
 	/* WEBPACK VAR INJECTION */(function(global) {
@@ -20549,13 +20839,12 @@
 	/* WEBPACK VAR INJECTION */}.call(exports, (function() { return this; }())))
 
 /***/ }),
-/* 53 */
+/* 54 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
-	var Buffer = __webpack_require__(24).Buffer;
-	var bufferShim = __webpack_require__(44);
+	var Buffer = __webpack_require__(44).Buffer;
 
 	var isEncoding = Buffer.isEncoding || function (encoding) {
 	  encoding = '' + encoding;
@@ -20632,7 +20921,7 @@
 	  }
 	  this.lastNeed = 0;
 	  this.lastTotal = 0;
-	  this.lastChar = bufferShim.allocUnsafe(nb);
+	  this.lastChar = Buffer.allocUnsafe(nb);
 	}
 
 	StringDecoder.prototype.write = function (buf) {
@@ -20827,8 +21116,29 @@
 	}
 
 /***/ }),
-/* 54 */
+/* 55 */
 /***/ (function(module, exports, __webpack_require__) {
+
+	// Copyright Joyent, Inc. and other Node contributors.
+	//
+	// Permission is hereby granted, free of charge, to any person obtaining a
+	// copy of this software and associated documentation files (the
+	// "Software"), to deal in the Software without restriction, including
+	// without limitation the rights to use, copy, modify, merge, publish,
+	// distribute, sublicense, and/or sell copies of the Software, and to permit
+	// persons to whom the Software is furnished to do so, subject to the
+	// following conditions:
+	//
+	// The above copyright notice and this permission notice shall be included
+	// in all copies or substantial portions of the Software.
+	//
+	// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+	// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+	// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+	// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+	// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+	// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+	// USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 	// a transform stream is a readable/writable stream where you do
 	// something with the data.  Sometimes it's called a "filter",
@@ -20876,7 +21186,7 @@
 
 	module.exports = Transform;
 
-	var Duplex = __webpack_require__(48);
+	var Duplex = __webpack_require__(49);
 
 	/*<replacement>*/
 	var util = __webpack_require__(45);
@@ -20903,7 +21213,9 @@
 
 	  var cb = ts.writecb;
 
-	  if (!cb) return stream.emit('error', new Error('no writecb in Transform class'));
+	  if (!cb) {
+	    return stream.emit('error', new Error('write callback called multiple times'));
+	  }
 
 	  ts.writechunk = null;
 	  ts.writecb = null;
@@ -20996,6 +21308,15 @@
 	  }
 	};
 
+	Transform.prototype._destroy = function (err, cb) {
+	  var _this = this;
+
+	  Duplex.prototype._destroy.call(this, err, function (err2) {
+	    cb(err2);
+	    _this.emit('close');
+	  });
+	};
+
 	function done(stream, er, data) {
 	  if (er) return stream.emit('error', er);
 
@@ -21014,8 +21335,29 @@
 	}
 
 /***/ }),
-/* 55 */
+/* 56 */
 /***/ (function(module, exports, __webpack_require__) {
+
+	// Copyright Joyent, Inc. and other Node contributors.
+	//
+	// Permission is hereby granted, free of charge, to any person obtaining a
+	// copy of this software and associated documentation files (the
+	// "Software"), to deal in the Software without restriction, including
+	// without limitation the rights to use, copy, modify, merge, publish,
+	// distribute, sublicense, and/or sell copies of the Software, and to permit
+	// persons to whom the Software is furnished to do so, subject to the
+	// following conditions:
+	//
+	// The above copyright notice and this permission notice shall be included
+	// in all copies or substantial portions of the Software.
+	//
+	// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+	// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+	// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+	// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+	// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+	// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+	// USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 	// a passthrough stream.
 	// basically just the most minimal sort of Transform stream.
@@ -21025,7 +21367,7 @@
 
 	module.exports = PassThrough;
 
-	var Transform = __webpack_require__(54);
+	var Transform = __webpack_require__(55);
 
 	/*<replacement>*/
 	var util = __webpack_require__(45);
@@ -21045,7 +21387,7 @@
 	};
 
 /***/ }),
-/* 56 */
+/* 57 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	var Buffer = __webpack_require__(24).Buffer
@@ -21078,7 +21420,7 @@
 
 
 /***/ }),
-/* 57 */
+/* 58 */
 /***/ (function(module, exports) {
 
 	module.exports = extend
@@ -21103,7 +21445,7 @@
 
 
 /***/ }),
-/* 58 */
+/* 59 */
 /***/ (function(module, exports) {
 
 	module.exports = {
@@ -21173,7 +21515,7 @@
 
 
 /***/ }),
-/* 59 */
+/* 60 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	// Copyright Joyent, Inc. and other Node contributors.
@@ -21199,8 +21541,8 @@
 
 	'use strict';
 
-	var punycode = __webpack_require__(60);
-	var util = __webpack_require__(61);
+	var punycode = __webpack_require__(61);
+	var util = __webpack_require__(62);
 
 	exports.parse = urlParse;
 	exports.resolve = urlResolve;
@@ -21275,7 +21617,7 @@
 	      'gopher:': true,
 	      'file:': true
 	    },
-	    querystring = __webpack_require__(62);
+	    querystring = __webpack_require__(63);
 
 	function urlParse(url, parseQueryString, slashesDenoteHost) {
 	  if (url && util.isObject(url) && url instanceof Url) return url;
@@ -21911,7 +22253,7 @@
 
 
 /***/ }),
-/* 60 */
+/* 61 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_RESULT__;/* WEBPACK VAR INJECTION */(function(module, global) {/*! https://mths.be/punycode v1.3.2 by @mathias */
@@ -22446,7 +22788,7 @@
 	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(9)(module), (function() { return this; }())))
 
 /***/ }),
-/* 61 */
+/* 62 */
 /***/ (function(module, exports) {
 
 	'use strict';
@@ -22468,17 +22810,17 @@
 
 
 /***/ }),
-/* 62 */
+/* 63 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
-	exports.decode = exports.parse = __webpack_require__(63);
-	exports.encode = exports.stringify = __webpack_require__(64);
+	exports.decode = exports.parse = __webpack_require__(64);
+	exports.encode = exports.stringify = __webpack_require__(65);
 
 
 /***/ }),
-/* 63 */
+/* 64 */
 /***/ (function(module, exports) {
 
 	// Copyright Joyent, Inc. and other Node contributors.
@@ -22564,7 +22906,7 @@
 
 
 /***/ }),
-/* 64 */
+/* 65 */
 /***/ (function(module, exports) {
 
 	// Copyright Joyent, Inc. and other Node contributors.
@@ -22634,7 +22976,7 @@
 
 
 /***/ }),
-/* 65 */
+/* 66 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	var http = __webpack_require__(35);
@@ -22654,7 +22996,7 @@
 
 
 /***/ }),
-/* 66 */
+/* 67 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(Buffer) {/*
@@ -22676,14 +23018,14 @@
 	 * under the License.
 	 */
 	var util = __webpack_require__(16);
-	var WebSocket = __webpack_require__(67);
+	var WebSocket = __webpack_require__(68);
 	var EventEmitter = __webpack_require__(21).EventEmitter;
 	var thrift = __webpack_require__(15);
-	var ttransport = __webpack_require__(68);
-	var tprotocol = __webpack_require__(70);
+	var ttransport = __webpack_require__(69);
+	var tprotocol = __webpack_require__(71);
 
 	var TBufferedTransport = __webpack_require__(23);
-	var TJSONProtocol = __webpack_require__(72);
+	var TJSONProtocol = __webpack_require__(73);
 	var InputBufferUnderrunError = __webpack_require__(29);
 
 	var createClient = __webpack_require__(33);
@@ -22947,7 +23289,7 @@
 	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(24).Buffer))
 
 /***/ }),
-/* 67 */
+/* 68 */
 /***/ (function(module, exports) {
 
 	
@@ -22996,7 +23338,7 @@
 
 
 /***/ }),
-/* 68 */
+/* 69 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	/*
@@ -23019,12 +23361,12 @@
 	 */
 
 	module.exports.TBufferedTransport = __webpack_require__(23);
-	module.exports.TFramedTransport = __webpack_require__(69);
+	module.exports.TFramedTransport = __webpack_require__(70);
 	module.exports.InputBufferUnderrunError = __webpack_require__(29);
 
 
 /***/ }),
-/* 69 */
+/* 70 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(Buffer) {/*
@@ -23213,7 +23555,7 @@
 	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(24).Buffer))
 
 /***/ }),
-/* 70 */
+/* 71 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	/*
@@ -23236,12 +23578,12 @@
 	 */
 
 	module.exports.TBinaryProtocol = __webpack_require__(30);
-	module.exports.TCompactProtocol = __webpack_require__(71);
-	module.exports.TJSONProtocol = __webpack_require__(72);
+	module.exports.TCompactProtocol = __webpack_require__(72);
+	module.exports.TJSONProtocol = __webpack_require__(73);
 
 
 /***/ }),
-/* 71 */
+/* 72 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(Buffer) {/*
@@ -24166,7 +24508,7 @@
 	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(24).Buffer))
 
 /***/ }),
-/* 72 */
+/* 73 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(Buffer) {/*
@@ -24190,13 +24532,13 @@
 
 	var log = __webpack_require__(31);
 	var Int64 = __webpack_require__(32);
-	var InputBufferUnderrunError = __webpack_require__(68).InputBufferUnderrunError;
+	var InputBufferUnderrunError = __webpack_require__(69).InputBufferUnderrunError;
 	var Thrift = __webpack_require__(15);
 	var Type = Thrift.Type;
 	var util = __webpack_require__(16);
 
-	var Int64Util = __webpack_require__(73);
-	var json_parse = __webpack_require__(74);
+	var Int64Util = __webpack_require__(74);
+	var json_parse = __webpack_require__(75);
 
 	var InputBufferUnderrunError = __webpack_require__(29);
 
@@ -24916,7 +25258,7 @@
 	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(24).Buffer))
 
 /***/ }),
-/* 73 */
+/* 74 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(Buffer) {/*
@@ -25014,7 +25356,7 @@
 	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(24).Buffer))
 
 /***/ }),
-/* 74 */
+/* 75 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	/*
@@ -25040,7 +25382,7 @@
 	*/
 
 	var Int64 = __webpack_require__(32);
-	var Int64Util = __webpack_require__(73);
+	var Int64Util = __webpack_require__(74);
 
 	var json_parse = module.exports = (function () {
 	    "use strict";
@@ -25319,7 +25661,7 @@
 
 
 /***/ }),
-/* 75 */
+/* 76 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(Buffer) {/*
@@ -25345,7 +25687,7 @@
 	var thrift = __webpack_require__(15);
 
 	var TBufferedTransport = __webpack_require__(23);
-	var TJSONProtocol = __webpack_require__(72);
+	var TJSONProtocol = __webpack_require__(73);
 	var InputBufferUnderrunError = __webpack_require__(29);
 
 	var createClient = __webpack_require__(33);
@@ -25606,7 +25948,7 @@
 	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(24).Buffer))
 
 /***/ }),
-/* 76 */
+/* 77 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	/*
@@ -25719,7 +26061,7 @@
 
 
 /***/ }),
-/* 77 */
+/* 78 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(Buffer) {/*
@@ -25741,13 +26083,13 @@
 	 * under the License.
 	 */
 	var http = __webpack_require__(35);
-	var https = __webpack_require__(65);
-	var url = __webpack_require__(59);
-	var path = __webpack_require__(78);
+	var https = __webpack_require__(66);
+	var url = __webpack_require__(60);
+	var path = __webpack_require__(79);
 	var fs = __webpack_require__(22);
-	var crypto = __webpack_require__(79);
+	var crypto = __webpack_require__(80);
 
-	var MultiplexedProcessor = __webpack_require__(113).MultiplexedProcessor;
+	var MultiplexedProcessor = __webpack_require__(114).MultiplexedProcessor;
 
 	var TBufferedTransport = __webpack_require__(23);
 	var TBinaryProtocol = __webpack_require__(30);
@@ -26290,7 +26632,7 @@
 	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(24).Buffer))
 
 /***/ }),
-/* 78 */
+/* 79 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(process) {// Copyright Joyent, Inc. and other Node contributors.
@@ -26521,10 +26863,10 @@
 	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(17)))
 
 /***/ }),
-/* 79 */
+/* 80 */
 /***/ (function(module, exports, __webpack_require__) {
 
-	/* WEBPACK VAR INJECTION */(function(Buffer) {var rng = __webpack_require__(80)
+	/* WEBPACK VAR INJECTION */(function(Buffer) {var rng = __webpack_require__(81)
 
 	function error () {
 	  var m = [].slice.call(arguments).join(' ')
@@ -26535,9 +26877,9 @@
 	    ].join('\n'))
 	}
 
-	exports.createHash = __webpack_require__(82)
+	exports.createHash = __webpack_require__(83)
 
-	exports.createHmac = __webpack_require__(91)
+	exports.createHmac = __webpack_require__(92)
 
 	exports.randomBytes = function(size, callback) {
 	  if (callback && callback.call) {
@@ -26558,10 +26900,10 @@
 	  return ['sha1', 'sha256', 'sha512', 'md5', 'rmd160']
 	}
 
-	var p = __webpack_require__(92)(exports)
+	var p = __webpack_require__(93)(exports)
 	exports.pbkdf2 = p.pbkdf2
 	exports.pbkdf2Sync = p.pbkdf2Sync
-	__webpack_require__(94)(exports, module.exports);
+	__webpack_require__(95)(exports, module.exports);
 
 	// the least I can do is make error messages for the rest of the node.js/crypto api.
 	each(['createCredentials'
@@ -26577,13 +26919,13 @@
 	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(24).Buffer))
 
 /***/ }),
-/* 80 */
+/* 81 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(global, Buffer) {(function() {
 	  var g = ('undefined' === typeof window ? global : window) || {}
 	  _crypto = (
-	    g.crypto || g.msCrypto || __webpack_require__(81)
+	    g.crypto || g.msCrypto || __webpack_require__(82)
 	  )
 	  module.exports = function(size) {
 	    // Modern Browsers
@@ -26610,19 +26952,19 @@
 	/* WEBPACK VAR INJECTION */}.call(exports, (function() { return this; }()), __webpack_require__(24).Buffer))
 
 /***/ }),
-/* 81 */
+/* 82 */
 /***/ (function(module, exports) {
 
 	/* (ignored) */
 
 /***/ }),
-/* 82 */
+/* 83 */
 /***/ (function(module, exports, __webpack_require__) {
 
-	/* WEBPACK VAR INJECTION */(function(Buffer) {var createHash = __webpack_require__(83)
+	/* WEBPACK VAR INJECTION */(function(Buffer) {var createHash = __webpack_require__(84)
 
-	var md5 = toConstructor(__webpack_require__(88))
-	var rmd160 = toConstructor(__webpack_require__(90))
+	var md5 = toConstructor(__webpack_require__(89))
+	var rmd160 = toConstructor(__webpack_require__(91))
 
 	function toConstructor (fn) {
 	  return function () {
@@ -26653,7 +26995,7 @@
 	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(24).Buffer))
 
 /***/ }),
-/* 83 */
+/* 84 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	var exports = module.exports = function (alg) {
@@ -26663,15 +27005,15 @@
 	}
 
 	var Buffer = __webpack_require__(24).Buffer
-	var Hash   = __webpack_require__(84)(Buffer)
+	var Hash   = __webpack_require__(85)(Buffer)
 
-	exports.sha1 = __webpack_require__(85)(Buffer, Hash)
-	exports.sha256 = __webpack_require__(86)(Buffer, Hash)
-	exports.sha512 = __webpack_require__(87)(Buffer, Hash)
+	exports.sha1 = __webpack_require__(86)(Buffer, Hash)
+	exports.sha256 = __webpack_require__(87)(Buffer, Hash)
+	exports.sha512 = __webpack_require__(88)(Buffer, Hash)
 
 
 /***/ }),
-/* 84 */
+/* 85 */
 /***/ (function(module, exports) {
 
 	module.exports = function (Buffer) {
@@ -26754,7 +27096,7 @@
 
 
 /***/ }),
-/* 85 */
+/* 86 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	/*
@@ -26898,7 +27240,7 @@
 
 
 /***/ }),
-/* 86 */
+/* 87 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	
@@ -27051,7 +27393,7 @@
 
 
 /***/ }),
-/* 87 */
+/* 88 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	var inherits = __webpack_require__(16).inherits
@@ -27301,7 +27643,7 @@
 
 
 /***/ }),
-/* 88 */
+/* 89 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	/*
@@ -27313,7 +27655,7 @@
 	 * See http://pajhome.org.uk/crypt/md5 for more info.
 	 */
 
-	var helpers = __webpack_require__(89);
+	var helpers = __webpack_require__(90);
 
 	/*
 	 * Calculate the MD5 of an array of little-endian words, and a bit length
@@ -27462,7 +27804,7 @@
 
 
 /***/ }),
-/* 89 */
+/* 90 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(Buffer) {var intSize = 4;
@@ -27503,7 +27845,7 @@
 	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(24).Buffer))
 
 /***/ }),
-/* 90 */
+/* 91 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(Buffer) {
@@ -27715,10 +28057,10 @@
 	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(24).Buffer))
 
 /***/ }),
-/* 91 */
+/* 92 */
 /***/ (function(module, exports, __webpack_require__) {
 
-	/* WEBPACK VAR INJECTION */(function(Buffer) {var createHash = __webpack_require__(82)
+	/* WEBPACK VAR INJECTION */(function(Buffer) {var createHash = __webpack_require__(83)
 
 	var zeroBuffer = new Buffer(128)
 	zeroBuffer.fill(0)
@@ -27765,10 +28107,10 @@
 	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(24).Buffer))
 
 /***/ }),
-/* 92 */
+/* 93 */
 /***/ (function(module, exports, __webpack_require__) {
 
-	var pbkdf2Export = __webpack_require__(93)
+	var pbkdf2Export = __webpack_require__(94)
 
 	module.exports = function (crypto, exports) {
 	  exports = exports || {}
@@ -27783,7 +28125,7 @@
 
 
 /***/ }),
-/* 93 */
+/* 94 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(Buffer) {module.exports = function(crypto) {
@@ -27874,18 +28216,18 @@
 	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(24).Buffer))
 
 /***/ }),
-/* 94 */
+/* 95 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	module.exports = function (crypto, exports) {
 	  exports = exports || {};
-	  var ciphers = __webpack_require__(95)(crypto);
+	  var ciphers = __webpack_require__(96)(crypto);
 	  exports.createCipher = ciphers.createCipher;
 	  exports.createCipheriv = ciphers.createCipheriv;
-	  var deciphers = __webpack_require__(112)(crypto);
+	  var deciphers = __webpack_require__(113)(crypto);
 	  exports.createDecipher = deciphers.createDecipher;
 	  exports.createDecipheriv = deciphers.createDecipheriv;
-	  var modes = __webpack_require__(103);
+	  var modes = __webpack_require__(104);
 	  function listCiphers () {
 	    return Object.keys(modes);
 	  }
@@ -27895,15 +28237,15 @@
 
 
 /***/ }),
-/* 95 */
+/* 96 */
 /***/ (function(module, exports, __webpack_require__) {
 
-	/* WEBPACK VAR INJECTION */(function(Buffer) {var aes = __webpack_require__(96);
-	var Transform = __webpack_require__(97);
+	/* WEBPACK VAR INJECTION */(function(Buffer) {var aes = __webpack_require__(97);
+	var Transform = __webpack_require__(98);
 	var inherits = __webpack_require__(38);
-	var modes = __webpack_require__(103);
-	var ebtk = __webpack_require__(104);
-	var StreamCipher = __webpack_require__(105);
+	var modes = __webpack_require__(104);
+	var ebtk = __webpack_require__(105);
+	var StreamCipher = __webpack_require__(106);
 	inherits(Cipher, Transform);
 	function Cipher(mode, key, iv) {
 	  if (!(this instanceof Cipher)) {
@@ -27964,11 +28306,11 @@
 	  return out;
 	};
 	var modelist = {
-	  ECB: __webpack_require__(106),
-	  CBC: __webpack_require__(107),
-	  CFB: __webpack_require__(109),
-	  OFB: __webpack_require__(110),
-	  CTR: __webpack_require__(111)
+	  ECB: __webpack_require__(107),
+	  CBC: __webpack_require__(108),
+	  CFB: __webpack_require__(110),
+	  OFB: __webpack_require__(111),
+	  CTR: __webpack_require__(112)
 	};
 	module.exports = function (crypto) {
 	  function createCipheriv(suite, password, iv) {
@@ -28010,7 +28352,7 @@
 	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(24).Buffer))
 
 /***/ }),
-/* 96 */
+/* 97 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(Buffer) {var uint_max = Math.pow(2, 32);
@@ -28212,10 +28554,10 @@
 	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(24).Buffer))
 
 /***/ }),
-/* 97 */
+/* 98 */
 /***/ (function(module, exports, __webpack_require__) {
 
-	/* WEBPACK VAR INJECTION */(function(Buffer) {var Transform = __webpack_require__(98).Transform;
+	/* WEBPACK VAR INJECTION */(function(Buffer) {var Transform = __webpack_require__(99).Transform;
 	var inherits = __webpack_require__(38);
 
 	module.exports = CipherBase;
@@ -28250,7 +28592,7 @@
 	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(24).Buffer))
 
 /***/ }),
-/* 98 */
+/* 99 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	// Copyright Joyent, Inc. and other Node contributors.
@@ -28281,10 +28623,10 @@
 
 	inherits(Stream, EE);
 	Stream.Readable = __webpack_require__(40);
-	Stream.Writable = __webpack_require__(99);
-	Stream.Duplex = __webpack_require__(100);
-	Stream.Transform = __webpack_require__(101);
-	Stream.PassThrough = __webpack_require__(102);
+	Stream.Writable = __webpack_require__(100);
+	Stream.Duplex = __webpack_require__(101);
+	Stream.Transform = __webpack_require__(102);
+	Stream.PassThrough = __webpack_require__(103);
 
 	// Backwards-compat with node 0.4.x
 	Stream.Stream = Stream;
@@ -28383,35 +28725,35 @@
 
 
 /***/ }),
-/* 99 */
-/***/ (function(module, exports, __webpack_require__) {
-
-	module.exports = __webpack_require__(49);
-
-
-/***/ }),
 /* 100 */
 /***/ (function(module, exports, __webpack_require__) {
 
-	module.exports = __webpack_require__(48);
+	module.exports = __webpack_require__(50);
 
 
 /***/ }),
 /* 101 */
 /***/ (function(module, exports, __webpack_require__) {
 
-	module.exports = __webpack_require__(40).Transform
+	module.exports = __webpack_require__(49);
 
 
 /***/ }),
 /* 102 */
 /***/ (function(module, exports, __webpack_require__) {
 
-	module.exports = __webpack_require__(40).PassThrough
+	module.exports = __webpack_require__(40).Transform
 
 
 /***/ }),
 /* 103 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	module.exports = __webpack_require__(40).PassThrough
+
+
+/***/ }),
+/* 104 */
 /***/ (function(module, exports) {
 
 	exports['aes-128-ecb'] = {
@@ -28524,7 +28866,7 @@
 	};
 
 /***/ }),
-/* 104 */
+/* 105 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(Buffer) {
@@ -28587,11 +28929,11 @@
 	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(24).Buffer))
 
 /***/ }),
-/* 105 */
+/* 106 */
 /***/ (function(module, exports, __webpack_require__) {
 
-	/* WEBPACK VAR INJECTION */(function(Buffer) {var aes = __webpack_require__(96);
-	var Transform = __webpack_require__(97);
+	/* WEBPACK VAR INJECTION */(function(Buffer) {var aes = __webpack_require__(97);
+	var Transform = __webpack_require__(98);
 	var inherits = __webpack_require__(38);
 
 	inherits(StreamCipher, Transform);
@@ -28619,7 +28961,7 @@
 	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(24).Buffer))
 
 /***/ }),
-/* 106 */
+/* 107 */
 /***/ (function(module, exports) {
 
 	exports.encrypt = function (self, block) {
@@ -28630,10 +28972,10 @@
 	};
 
 /***/ }),
-/* 107 */
+/* 108 */
 /***/ (function(module, exports, __webpack_require__) {
 
-	var xor = __webpack_require__(108);
+	var xor = __webpack_require__(109);
 	exports.encrypt = function (self, block) {
 	  var data = xor(block, self._prev);
 	  self._prev = self._cipher.encryptBlock(data);
@@ -28647,7 +28989,7 @@
 	};
 
 /***/ }),
-/* 108 */
+/* 109 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(Buffer) {module.exports = xor;
@@ -28663,10 +29005,10 @@
 	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(24).Buffer))
 
 /***/ }),
-/* 109 */
+/* 110 */
 /***/ (function(module, exports, __webpack_require__) {
 
-	/* WEBPACK VAR INJECTION */(function(Buffer) {var xor = __webpack_require__(108);
+	/* WEBPACK VAR INJECTION */(function(Buffer) {var xor = __webpack_require__(109);
 	exports.encrypt = function (self, data, decrypt) {
 	  var out = new Buffer('');
 	  var len;
@@ -28696,10 +29038,10 @@
 	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(24).Buffer))
 
 /***/ }),
-/* 110 */
+/* 111 */
 /***/ (function(module, exports, __webpack_require__) {
 
-	/* WEBPACK VAR INJECTION */(function(Buffer) {var xor = __webpack_require__(108);
+	/* WEBPACK VAR INJECTION */(function(Buffer) {var xor = __webpack_require__(109);
 	function getBlock(self) {
 	  self._prev = self._cipher.encryptBlock(self._prev);
 	  return self._prev;
@@ -28715,10 +29057,10 @@
 	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(24).Buffer))
 
 /***/ }),
-/* 111 */
+/* 112 */
 /***/ (function(module, exports, __webpack_require__) {
 
-	/* WEBPACK VAR INJECTION */(function(Buffer) {var xor = __webpack_require__(108);
+	/* WEBPACK VAR INJECTION */(function(Buffer) {var xor = __webpack_require__(109);
 	function getBlock(self) {
 	  var out = self._cipher.encryptBlock(self._prev);
 	  incr32(self._prev);
@@ -28749,15 +29091,15 @@
 	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(24).Buffer))
 
 /***/ }),
-/* 112 */
+/* 113 */
 /***/ (function(module, exports, __webpack_require__) {
 
-	/* WEBPACK VAR INJECTION */(function(Buffer) {var aes = __webpack_require__(96);
-	var Transform = __webpack_require__(97);
+	/* WEBPACK VAR INJECTION */(function(Buffer) {var aes = __webpack_require__(97);
+	var Transform = __webpack_require__(98);
 	var inherits = __webpack_require__(38);
-	var modes = __webpack_require__(103);
-	var StreamCipher = __webpack_require__(105);
-	var ebtk = __webpack_require__(104);
+	var modes = __webpack_require__(104);
+	var StreamCipher = __webpack_require__(106);
+	var ebtk = __webpack_require__(105);
 
 	inherits(Decipher, Transform);
 	function Decipher(mode, key, iv) {
@@ -28825,11 +29167,11 @@
 	}
 
 	var modelist = {
-	  ECB: __webpack_require__(106),
-	  CBC: __webpack_require__(107),
-	  CFB: __webpack_require__(109),
-	  OFB: __webpack_require__(110),
-	  CTR: __webpack_require__(111)
+	  ECB: __webpack_require__(107),
+	  CBC: __webpack_require__(108),
+	  CFB: __webpack_require__(110),
+	  OFB: __webpack_require__(111),
+	  CTR: __webpack_require__(112)
 	};
 
 	module.exports = function (crypto) {
@@ -28873,7 +29215,7 @@
 	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(24).Buffer))
 
 /***/ }),
-/* 113 */
+/* 114 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	/*
@@ -28942,7 +29284,7 @@
 
 
 /***/ }),
-/* 114 */
+/* 115 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(process, setImmediate) {// vim:ts=4:sts=4:sw=4:
@@ -30850,10 +31192,10 @@
 
 	});
 
-	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(17), __webpack_require__(50).setImmediate))
+	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(17), __webpack_require__(51).setImmediate))
 
 /***/ }),
-/* 115 */
+/* 116 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	/*
@@ -30932,7 +31274,7 @@
 
 
 /***/ }),
-/* 116 */
+/* 117 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -35056,7 +35398,7 @@
 	};
 
 /***/ }),
-/* 117 */
+/* 118 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -35066,11 +35408,11 @@
 	});
 	exports.default = processQueryResults;
 
-	var _processColumnarResults = __webpack_require__(118);
+	var _processColumnarResults = __webpack_require__(119);
 
 	var _processColumnarResults2 = _interopRequireDefault(_processColumnarResults);
 
-	var _processRowResults = __webpack_require__(119);
+	var _processRowResults = __webpack_require__(120);
 
 	var _processRowResults2 = _interopRequireDefault(_processRowResults);
 
@@ -35081,6 +35423,7 @@
 	   *
 	   * @param {Boolean} logging if enabled, will show how long the query took to execute in console
 	   * @param {Function} updateQueryTimes A function that updates internal query times on connector
+	   * @param {Function} logger A function logs timing info; defaults to console.log.
 	   * @param {Object} options A list of options for processing the results
 	   * @param {Boolean} options.isImage Set to true when querying for backend rendered images
 	   * @param {Boolean} options.eliminateNullRows Removes null rows
@@ -35095,6 +35438,8 @@
 	   *                  otherwise formatted results
 	   */
 	function processQueryResults(logging, updateQueryTimes) {
+	  var logger = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : console.log;
+	  // eslint-disable-line no-console
 	  return function (options, _datumEnum, result, callback) {
 	    var isImage = false;
 	    var eliminateNullRows = false;
@@ -35104,7 +35449,7 @@
 	    var estimatedQueryTime = null;
 	    var hasCallback = Boolean(callback);
 
-	    if (typeof options !== "undefined") {
+	    if (typeof options !== "undefined" && options !== null) {
 	      isImage = options.isImage ? options.isImage : false;
 	      eliminateNullRows = options.eliminateNullRows ? options.eliminateNullRows : false;
 	      query = options.query ? options.query : null;
@@ -35112,29 +35457,29 @@
 	      conId = typeof options.conId === "undefined" ? null : options.conId;
 	      estimatedQueryTime = typeof options.estimatedQueryTime === "undefined" ? null : options.estimatedQueryTime;
 	    }
-	    if (result.execution_time_ms && conId !== null && estimatedQueryTime !== null) {
+	    if (result && result.execution_time_ms && conId !== null && estimatedQueryTime !== null) {
 	      updateQueryTimes(conId, queryId, estimatedQueryTime, result.execution_time_ms);
 	    }
 
 	    // should use node_env
 	    if (logging && result.execution_time_ms) {
-	      console.log(query, "on Server", conId, "- Execution Time:", result.execution_time_ms, " ms, Total Time:", result.total_time_ms + "ms");
+	      logger(query, "on Server", conId, "- Execution Time:", result.execution_time_ms, " ms, Total Time:", result.total_time_ms + "ms");
 	    }
 
 	    if (isImage && hasCallback) {
-	      callback(null, result);
+	      return callback(null, result);
 	    } else if (isImage && !hasCallback) {
 	      return result;
 	    } else {
+	      // !isImage
 	      var formattedResult = null;
 
-	      if (!result.row_set) {
+	      if (!result || !result.row_set) {
 	        if (hasCallback) {
-	          callback(new Error("No result to process"));
+	          return callback(new Error("No result to process"));
 	        } else {
 	          throw new Error("No result to process");
 	        }
-	        return;
 	      }
 
 	      if (result.row_set.is_columnar) {
@@ -35149,16 +35494,16 @@
 	      };
 
 	      if (hasCallback) {
-	        callback(null, options.returnTiming ? formattedResult : formattedResult.results);
+	        return callback(null, options && options.returnTiming ? formattedResult : formattedResult.results);
 	      } else {
-	        return options.returnTiming ? formattedResult : formattedResult.results;
+	        return options && options.returnTiming ? formattedResult : formattedResult.results;
 	      }
 	    }
 	  };
 	}
 
 /***/ }),
-/* 118 */
+/* 119 */
 /***/ (function(module, exports) {
 
 	"use strict";
@@ -35282,7 +35627,7 @@
 	}
 
 /***/ }),
-/* 119 */
+/* 120 */
 /***/ (function(module, exports) {
 
 	"use strict";

--- a/src/mapd-con-es6.js
+++ b/src/mapd-con-es6.js
@@ -932,6 +932,7 @@ class MapdCon {
    * @returns {Object} An object with the pixel results formatted for display
    */
   processPixelResults (callbacks, error, results) {
+    const hasCallbacks = Boolean(callbacks)
     callbacks = Array.isArray(callbacks) ? callbacks : [callbacks]
     results = Array.isArray(results) ? results.pixel_rows : [results]
     const numPixels = results.length
@@ -941,13 +942,22 @@ class MapdCon {
       query: "pixel request",
       queryId: -2
     }
-    for (let p = 0; p < numPixels; p++) {
-      results[p].row_set = this.processResults(processResultsOptions, results[p])
+    if (error) {
+      if (hasCallbacks) {
+        return callbacks.pop()(error)
+      } else {
+        throw error
+      }
+    } else {
+      for (let p = 0; p < numPixels; p++) {
+        results[p].row_set = this.processResults(processResultsOptions, results[p])
+      }
+      if (hasCallbacks) {
+        return callbacks.pop()(null, results)
+      } else {
+        return results
+      }
     }
-    if (!callbacks) {
-      return results
-    }
-    callbacks.pop()(error, results)
   }
 
   /**

--- a/test/integration.spec.js
+++ b/test/integration.spec.js
@@ -1,3 +1,5 @@
+/* eslint-disable max-nested-callbacks */
+/* eslint-disable no-magic-numbers */
 "use strict"
 const isNodeRuntime = typeof window === "undefined"
 const expect = isNodeRuntime ? require("chai").expect : window.expect
@@ -11,7 +13,7 @@ const imageRegex = /^iVBOR/
 const emptyImageRegex = /^.{70,90}(.{12})\1+.{30,50}$/
 
 describe(isNodeRuntime ? "node" : "browser", () => {
-  let connector
+  let connector = null
   beforeEach(() => {
     connector = new Connector().protocol("https").host("metis.mapd.com").port("443").dbName("mapd").user("mapd").password("HyperInteractive")
   })
@@ -186,7 +188,7 @@ describe(isNodeRuntime ? "node" : "browser", () => {
         expect(renderVegaError).to.not.be.an("error")
         session.getResultRowForPixel(widgetId, pixel, tableColNamesMap, (pixelError, data) => {
           expect(pixelError).to.not.be.an("error")
-          expect(data[0].row_set).to.deep.equal([{dest_lon: -119.056770324707}]) // Ran 100 times; seems deterministic.
+          expect(data[0].row_set).to.deep.equal([{dest_lon: -119.05677032470703}]) // Ran 100 times; seems deterministic.
           done()
         })
       })

--- a/test/process-query-results.unit.spec.js
+++ b/test/process-query-results.unit.spec.js
@@ -1,0 +1,164 @@
+/* eslint-disable no-unused-expressions */
+/* eslint-disable init-declarations */
+import {expect} from "chai"
+import processQueryResults from "../src/process-query-results.js"
+
+const noop = () => { /* noop */ }
+
+describe("processQueryResults", () => {
+  let logging
+  let updateQueryTimes
+  let options
+  let _datumEnum
+  let result
+  let callback
+
+  beforeEach(() => {
+    logging = false
+    updateQueryTimes = noop
+    options = {}
+    _datumEnum = {}
+    result = {row_set: {rows: [], row_desc: []}}
+    callback = null
+  })
+
+  it("processes row result", done => {
+    callback = (error, data) => {
+      expect(error).to.be.null
+      expect(data).to.deep.equal([])
+      done()
+    }
+    processQueryResults(logging, updateQueryTimes)(options, _datumEnum, result, callback)
+  })
+
+  it("processes columnar result", done => {
+    result = {row_set: {is_columnar: true, row_desc: [], columns: []}}
+    callback = (error, data) => {
+      expect(error).to.be.null
+      expect(data).to.deep.equal([])
+      done()
+    }
+    processQueryResults(logging, updateQueryTimes)(options, _datumEnum, result, callback)
+  })
+
+  it("errors for undefined result", done => {
+    result = undefined // eslint-disable-line no-undefined
+    callback = error => {
+      expect(error.message).to.equal("No result to process")
+      done()
+    }
+    processQueryResults(logging, updateQueryTimes)(options, _datumEnum, result, callback)
+  })
+
+  it("doesn't blow up on undefined options", done => {
+    options = undefined // eslint-disable-line no-undefined
+    callback = (error, data) => {
+      expect(error).to.be.null
+      expect(data).to.deep.equal([])
+      done()
+    }
+    processQueryResults(logging, updateQueryTimes)(options, _datumEnum, result, callback)
+  })
+
+  it("doesn't blow up on null options", done => {
+    options = null
+    callback = (error, data) => {
+      expect(error).to.be.null
+      expect(data).to.deep.equal([])
+      done()
+    }
+    processQueryResults(logging, updateQueryTimes)(options, _datumEnum, result, callback)
+  })
+
+  it("returns result if no callback", () => {
+    callback = null
+    const data = processQueryResults(logging, updateQueryTimes)(options, _datumEnum, result, callback)
+    expect(data).to.deep.equal([])
+  })
+
+  it("throws if no result and no callback", () => {
+    result = null
+    callback = null
+    expect(() => processQueryResults(logging, updateQueryTimes)(options, _datumEnum, result, callback))
+    .to.throw("No result to process")
+  })
+
+  it("just returns result if options say it's an image and no callback", () => {
+    options = {isImage: true}
+    callback = null
+    const data = processQueryResults(logging, updateQueryTimes)(options, _datumEnum, result, callback)
+    expect(data).to.equal(result)
+  })
+
+  it("just calls back with result if options say it's an image", done => {
+    options = {isImage: true}
+    callback = (error, data) => {
+      expect(error).to.be.null
+      expect(data).to.equal(result)
+      done()
+    }
+    processQueryResults(logging, updateQueryTimes)(options, _datumEnum, result, callback)
+  })
+
+  it("logs if logging enabled and result has timing info", () => {
+    logging = true
+    result = {execution_time_ms: 1, total_time_ms: 2, row_set: {rows: [], row_desc: []}}
+    options = {query: "select foo from bar", conId: 0}
+    const logger = (...args) => expect(args).to.deep.equal([
+      "select foo from bar",
+      "on Server",
+      0,
+      "- Execution Time:",
+      1,
+      " ms, Total Time:",
+      "2ms"
+    ])
+    processQueryResults(logging, updateQueryTimes, logger)(options, _datumEnum, result, callback)
+  })
+
+  // it("doesn't log without execution_time_ms", () => {
+  //   logging = true
+  //   result = {execution_time_ms: 1, row_set: {rows: [], row_desc: []}}
+  //   options = {query: "select foo from bar", conId: 0}
+  //   const logger = () => expect.fail(0, 0, "should not log")
+  //   processQueryResults(logging, updateQueryTimes, logger)(options, _datumEnum, result, callback)
+  // })
+
+  it("updates query times when result.execution_time_ms, conId, estimatedQueryTime", () => {
+    result = {execution_time_ms: 2, row_set: {rows: [], row_desc: []}}
+    options = {conId: 0, queryId: -1, estimatedQueryTime: 1}
+    updateQueryTimes = (...args) => expect(args).to.deep.equal([0, -1, 1, 2])
+    processQueryResults(logging, updateQueryTimes)(options, _datumEnum, result, callback)
+  })
+
+  it("can eliminate null rows without blowing up", () => {
+    options = {eliminateNullRows: true}
+    processQueryResults(logging, updateQueryTimes)(options, _datumEnum, result, callback)
+  })
+
+  it("returns timing data if requested", () => {
+    options = {returnTiming: true}
+    result = {execution_time_ms: 2, total_time_ms: 1, row_set: {rows: [], row_desc: []}}
+    const data = processQueryResults(logging, updateQueryTimes)(options, _datumEnum, result, callback)
+    expect(data.results).to.deep.equal([])
+    expect(data.timing).to.deep.equal({
+      execution_time_ms: 2,
+      total_time_ms: 1
+    })
+  })
+
+  it("calls back with timing data if requested", done => {
+    options = {returnTiming: true}
+    result = {execution_time_ms: 2, total_time_ms: 1, row_set: {rows: [], row_desc: []}}
+    callback = (error, data) => {
+      expect(error).to.be.null
+      expect(data.results).to.deep.equal([])
+      expect(data.timing).to.deep.equal({
+        execution_time_ms: 2,
+        total_time_ms: 1
+      })
+      done()
+    }
+    processQueryResults(logging, updateQueryTimes)(options, _datumEnum, result, callback)
+  })
+})


### PR DESCRIPTION
As this is not a pressing issue, I want to change this to be against v3 instead of v2.

# Merge Checklist
## :wrench: Issue(s) fixed:
- when pixel result is undefined, it causes a `can't read property of undefined` error [in process-query-resultsL39](https://github.com/mapd/mapd-connector/blob/master/src/process-query-results.js#L39)
- exposes underlying error in https://github.com/mapd/mapd-immerse/issues/3030

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.

When finished, I'll 
- create a new release from this (likely 2.0.2)
- add this into the v3 branch