### PR TITLE
at_most_n argument to sql_execute

### DIFF
--- a/dist/browser-connector.js
+++ b/dist/browser-connector.js
@@ -836,8 +836,9 @@
 	      };
 
 	      try {
+	        var AT_MOST_N = -1;
 	        if (callback) {
-	          this._client[conId].sql_execute(this._sessionId[conId], _query, columnarResults, curNonce, limit, function (error, result) {
+	          this._client[conId].sql_execute(this._sessionId[conId], _query, columnarResults, curNonce, limit, AT_MOST_N, function (error, result) {
 	            if (error) {
 	              callback(error);
 	            } else {
@@ -846,7 +847,7 @@
 	          });
 	          return curNonce;
 	        } else if (!callback) {
-	          var SQLExecuteResult = this._client[conId].sql_execute(this._sessionId[conId], _query, columnarResults, curNonce, limit);
+	          var SQLExecuteResult = this._client[conId].sql_execute(this._sessionId[conId], _query, columnarResults, curNonce, limit, AT_MOST_N);
 	          return this.processResults(processResultsOptions, SQLExecuteResult);
 	        }
 	      } catch (err) {

--- a/dist/node-connector.js
+++ b/dist/node-connector.js
@@ -30859,8 +30859,9 @@ module.exports =
 	      };
 
 	      try {
+	        var AT_MOST_N = -1;
 	        if (callback) {
-	          this._client[conId].sql_execute(this._sessionId[conId], _query, columnarResults, curNonce, limit, function (error, result) {
+	          this._client[conId].sql_execute(this._sessionId[conId], _query, columnarResults, curNonce, limit, AT_MOST_N, function (error, result) {
 	            if (error) {
 	              callback(error);
 	            } else {
@@ -30869,7 +30870,7 @@ module.exports =
 	          });
 	          return curNonce;
 	        } else if (!callback) {
-	          var SQLExecuteResult = this._client[conId].sql_execute(this._sessionId[conId], _query, columnarResults, curNonce, limit);
+	          var SQLExecuteResult = this._client[conId].sql_execute(this._sessionId[conId], _query, columnarResults, curNonce, limit, AT_MOST_N);
 	          return this.processResults(processResultsOptions, SQLExecuteResult);
 	        }
 	      } catch (err) {

--- a/src/mapd-con-es6.js
+++ b/src/mapd-con-es6.js
@@ -616,8 +616,9 @@ class MapdCon {
     }
 
     try {
+      const AT_MOST_N = -1
       if (callback) {
-        this._client[conId].sql_execute(this._sessionId[conId], query, columnarResults, curNonce, limit, (error, result) => {
+        this._client[conId].sql_execute(this._sessionId[conId], query, columnarResults, curNonce, limit, AT_MOST_N, (error, result) => {
           if (error) {
             callback(error)
           } else {
@@ -631,7 +632,8 @@ class MapdCon {
           query,
           columnarResults,
           curNonce,
-          limit
+          limit,
+          AT_MOST_N
         )
         return this.processResults(processResultsOptions, SQLExecuteResult)
       }


### PR DESCRIPTION
The signature of `sql_execute` changed in thrift. It now needs an `at_most_n` last argument, that I set to `-1` to disable.

@mrblueblue I don't know if it should be merged to the 2.0.1 branch and then tagged to 2.0.3?

# Merge Checklist
## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR:
- [ ] Fixes #0

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
