### PR TITLE
Properly throw error in processPixelResults

### DIFF
--- a/dist/browser-connector.js
+++ b/dist/browser-connector.js
@@ -66,10 +66,27 @@
 		Author Tobias Koppers @sokra
 	*/
 	module.exports = function(src) {
-		if (typeof execScript !== "undefined")
-			execScript(src);
-		else
-			eval.call(null, src);
+		function log(error) {
+			(typeof console !== "undefined")
+			&& (console.error || console.log)("[Script Loader]", error);
+		}
+
+		// Check for IE =< 8
+		function isIE() {
+			return typeof attachEvent !== "undefined" && typeof addEventListener === "undefined";
+		}
+
+		try {
+			if (typeof execScript !== "undefined" && isIE()) {
+				execScript(src);
+			} else if (typeof eval !== "undefined") {
+				eval.call(null, src);
+			} else {
+				log("EvalError: No eval function available");
+			}
+		} catch (error) {
+			log(error);
+		}
 	}
 
 
@@ -1255,6 +1272,13 @@
 	    value: function processPixelResults(callbacks, error, results) {
 	      callbacks = Array.isArray(callbacks) ? callbacks : [callbacks];
 	      results = Array.isArray(results) ? results.pixel_rows : [results];
+	      if (error) {
+	        if (callbacks) {
+	          callbacks.pop()(error, results);
+	        } else {
+	          throw new Error("Unable to process result row for pixel results: " + error);
+	        }
+	      }
 	      var numPixels = results.length;
 	      var processResultsOptions = {
 	        isImage: false,

--- a/dist/node-connector.js
+++ b/dist/node-connector.js
@@ -17297,6 +17297,13 @@ module.exports =
 	    value: function processPixelResults(callbacks, error, results) {
 	      callbacks = Array.isArray(callbacks) ? callbacks : [callbacks];
 	      results = Array.isArray(results) ? results.pixel_rows : [results];
+	      if (error) {
+	        if (callbacks) {
+	          callbacks.pop()(error, results);
+	        } else {
+	          throw new Error("Unable to process result row for pixel results: " + error);
+	        }
+	      }
 	      var numPixels = results.length;
 	      var processResultsOptions = {
 	        isImage: false,

--- a/src/mapd-con-es6.js
+++ b/src/mapd-con-es6.js
@@ -1197,6 +1197,13 @@ class MapdCon {
   processPixelResults(callbacks, error, results) {
     callbacks = Array.isArray(callbacks) ? callbacks : [callbacks]
     results = Array.isArray(results) ? results.pixel_rows : [results]
+    if (error) {
+      if (callbacks) {
+        callbacks.pop()(error, results)
+      } else {
+        throw new Error(`Unable to process result row for pixel results: ${error}`)
+      }
+    }
     const numPixels = results.length
     const processResultsOptions = {
       isImage: false,


### PR DESCRIPTION
If the result row for pixel query fails and an error is returned, the results object will be null or undefined. However, processPixelResults attempts to read properties from the results object before the error can be propagated to the calling function. This results in an "attempt to access property of undefined" error, missing the original error returned from the server.  This change provides an early out, throwing or returning the error immediately so the caller can understand what went wrong.

# Merge Checklist
## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR:
- [ ] Fixes #0

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
