### PR TITLE
Add GeoType support and throw errors if type not detected

### DIFF
--- a/dist/browser-connector.js
+++ b/dist/browser-connector.js
@@ -1553,22 +1553,18 @@
 	        estimatedQueryTime: lastQueryTime
 	      };
 
-	      try {
-	        if (!callback) {
-	          var renderResult = this._client[conId].render_vega(this._sessionId[conId], widgetid, vega, compressionLevel, curNonce);
-	          return this.processResults(processResultsOptions, renderResult);
-	        }
-
-	        this._client[conId].render_vega(this._sessionId[conId], widgetid, vega, compressionLevel, curNonce, function (error, result) {
-	          if (error) {
-	            callback(error);
-	          } else {
-	            _this15.processResults(processResultsOptions, result, callback);
-	          }
-	        });
-	      } catch (err) {
-	        throw err;
+	      if (!callback) {
+	        var renderResult = this._client[conId].render_vega(this._sessionId[conId], widgetid, vega, compressionLevel, curNonce);
+	        return this.processResults(processResultsOptions, renderResult);
 	      }
+
+	      this._client[conId].render_vega(this._sessionId[conId], widgetid, vega, compressionLevel, curNonce, function (error, result) {
+	        if (error) {
+	          callback(error);
+	        } else {
+	          _this15.processResults(processResultsOptions, result, callback);
+	        }
+	      });
 
 	      return curNonce;
 	    }
@@ -1595,15 +1591,13 @@
 	      }
 	      var columnFormat = true; // BOOL
 	      var curNonce = (this._nonce++).toString();
-	      try {
-	        if (!callbacks) {
-	          return this.processPixelResults(undefined, // eslint-disable-line no-undefined
-	          this._client[this._lastRenderCon].get_result_row_for_pixel(this._sessionId[this._lastRenderCon], widgetId, pixel, tableColNamesMap, columnFormat, pixelRadius, curNonce));
-	        }
-	        this._client[this._lastRenderCon].get_result_row_for_pixel(this._sessionId[this._lastRenderCon], widgetId, pixel, tableColNamesMap, columnFormat, pixelRadius, curNonce, this.processPixelResults.bind(this, callbacks));
-	      } catch (err) {
-	        throw err;
+
+	      if (!callbacks) {
+	        return this.processPixelResults(undefined, // eslint-disable-line no-undefined
+	        this._client[this._lastRenderCon].get_result_row_for_pixel(this._sessionId[this._lastRenderCon], widgetId, pixel, tableColNamesMap, columnFormat, pixelRadius, curNonce));
 	      }
+	      this._client[this._lastRenderCon].get_result_row_for_pixel(this._sessionId[this._lastRenderCon], widgetId, pixel, tableColNamesMap, columnFormat, pixelRadius, curNonce, this.processPixelResults.bind(this, callbacks));
+
 	      return curNonce;
 	    }
 
@@ -26938,16 +26932,25 @@
 	        return;
 	      }
 
-	      if (result.row_set.is_columnar) {
-	        formattedResult = (0, _processColumnarResults2.default)(result.row_set, eliminateNullRows, _datumEnum);
-	      } else {
-	        formattedResult = (0, _processRowResults2.default)(result.row_set, eliminateNullRows, _datumEnum);
-	      }
+	      try {
+	        if (result.row_set.is_columnar) {
+	          formattedResult = (0, _processColumnarResults2.default)(result.row_set, eliminateNullRows, _datumEnum);
+	        } else {
+	          formattedResult = (0, _processRowResults2.default)(result.row_set, eliminateNullRows, _datumEnum);
+	        }
 
-	      formattedResult.timing = {
-	        execution_time_ms: result.execution_time_ms,
-	        total_time_ms: result.total_time_ms
-	      };
+	        formattedResult.timing = {
+	          execution_time_ms: result.execution_time_ms,
+	          total_time_ms: result.total_time_ms
+	        };
+	      } catch (err) {
+	        if (hasCallback) {
+	          callback(err);
+	        } else {
+	          throw err;
+	        }
+	        return;
+	      }
 
 	      if (hasCallback) {
 	        callback(null, options.returnTiming ? formattedResult : formattedResult.results);
@@ -27048,7 +27051,7 @@
 	              row[fieldName].push(data.columns[_c].data.arr_col[r].data.int_col[e] * oneThousandMilliseconds);
 	              break;
 	            default:
-	              break;
+	              throw new Error("Unrecognized array field type: " + fieldType);
 	          }
 	        }
 	      } else {
@@ -27074,8 +27077,14 @@
 	          case "DATE":
 	            row[fieldName] = new Date(data.columns[_c].data.int_col[r] * oneThousandMilliseconds);
 	            break;
-	          default:
+	          case "POINT":
+	          case "LINESTRING":
+	          case "POLYGON":
+	          case "MULTIPOLYGON":
+	            row[fieldName] = data.columns[_c].data.str_col[r];
 	            break;
+	          default:
+	            throw new Error("Unrecognized field type: " + fieldType);
 	        }
 	      }
 	    }
@@ -27176,7 +27185,7 @@
 	              row[fieldName].push(elemDatum.val.int_val * 1000); // eslint-disable-line no-magic-numbers
 	              break;
 	            default:
-	              break;
+	              throw new Error("Unrecognized array field type: " + fieldType);
 	          }
 	        }
 	      } else {
@@ -27207,8 +27216,14 @@
 	          case "DATE":
 	            row[fieldName] = new Date(scalarDatum.val.int_val * 1000); // eslint-disable-line no-magic-numbers
 	            break;
-	          default:
+	          case "POINT":
+	          case "LINESTRING":
+	          case "POLYGON":
+	          case "MULTIPOLYGON":
+	            row[fieldName] = scalarDatum.val.str_val;
 	            break;
+	          default:
+	            throw new Error("Unrecognized field type: " + fieldType);
 	        }
 	      }
 	    }

--- a/src/mapd-con-es6.js
+++ b/src/mapd-con-es6.js
@@ -1417,35 +1417,31 @@ class MapdCon {
       estimatedQueryTime: lastQueryTime
     }
 
-    try {
-      if (!callback) {
-        const renderResult = this._client[conId].render_vega(
-          this._sessionId[conId],
-          widgetid,
-          vega,
-          compressionLevel,
-          curNonce
-        )
-        return this.processResults(processResultsOptions, renderResult)
-      }
-
-      this._client[conId].render_vega(
+    if (!callback) {
+      const renderResult = this._client[conId].render_vega(
         this._sessionId[conId],
         widgetid,
         vega,
         compressionLevel,
-        curNonce,
-        (error, result) => {
-          if (error) {
-            callback(error)
-          } else {
-            this.processResults(processResultsOptions, result, callback)
-          }
-        }
+        curNonce
       )
-    } catch (err) {
-      throw err
+      return this.processResults(processResultsOptions, renderResult)
     }
+
+    this._client[conId].render_vega(
+      this._sessionId[conId],
+      widgetid,
+      vega,
+      compressionLevel,
+      curNonce,
+      (error, result) => {
+        if (error) {
+          callback(error)
+        } else {
+          this.processResults(processResultsOptions, result, callback)
+        }
+      }
+    )
 
     return curNonce
   }
@@ -1474,34 +1470,32 @@ class MapdCon {
     }
     const columnFormat = true // BOOL
     const curNonce = (this._nonce++).toString()
-    try {
-      if (!callbacks) {
-        return this.processPixelResults(
-          undefined, // eslint-disable-line no-undefined
-          this._client[this._lastRenderCon].get_result_row_for_pixel(
-            this._sessionId[this._lastRenderCon],
-            widgetId,
-            pixel,
-            tableColNamesMap,
-            columnFormat,
-            pixelRadius,
-            curNonce
-          )
+
+    if (!callbacks) {
+      return this.processPixelResults(
+        undefined, // eslint-disable-line no-undefined
+        this._client[this._lastRenderCon].get_result_row_for_pixel(
+          this._sessionId[this._lastRenderCon],
+          widgetId,
+          pixel,
+          tableColNamesMap,
+          columnFormat,
+          pixelRadius,
+          curNonce
         )
-      }
-      this._client[this._lastRenderCon].get_result_row_for_pixel(
-        this._sessionId[this._lastRenderCon],
-        widgetId,
-        pixel,
-        tableColNamesMap,
-        columnFormat,
-        pixelRadius,
-        curNonce,
-        this.processPixelResults.bind(this, callbacks)
       )
-    } catch (err) {
-      throw err
     }
+    this._client[this._lastRenderCon].get_result_row_for_pixel(
+      this._sessionId[this._lastRenderCon],
+      widgetId,
+      pixel,
+      tableColNamesMap,
+      columnFormat,
+      pixelRadius,
+      curNonce,
+      this.processPixelResults.bind(this, callbacks)
+    )
+
     return curNonce
   }
 

--- a/src/process-columnar-results.js
+++ b/src/process-columnar-results.js
@@ -92,7 +92,7 @@ export default function processColumnarResults(
               )
               break
             default:
-              break
+              throw new Error("Unrecognized array field type: " + fieldType)
           }
         }
       } else {
@@ -120,8 +120,14 @@ export default function processColumnarResults(
               data.columns[c].data.int_col[r] * oneThousandMilliseconds
             )
             break
-          default:
+          case "POINT":
+          case "LINESTRING":
+          case "POLYGON":
+          case "MULTIPOLYGON":
+            row[fieldName] = data.columns[c].data.str_col[r]
             break
+          default:
+            throw new Error("Unrecognized field type: " + fieldType)
         }
       }
     }

--- a/src/process-query-results.js
+++ b/src/process-query-results.js
@@ -83,23 +83,32 @@ export default function processQueryResults(logging, updateQueryTimes) {
         return
       }
 
-      if (result.row_set.is_columnar) {
-        formattedResult = processColumnarResults(
-          result.row_set,
-          eliminateNullRows,
-          _datumEnum
-        )
-      } else {
-        formattedResult = processRowResults(
-          result.row_set,
-          eliminateNullRows,
-          _datumEnum
-        )
-      }
+      try {
+        if (result.row_set.is_columnar) {
+          formattedResult = processColumnarResults(
+            result.row_set,
+            eliminateNullRows,
+            _datumEnum
+          )
+        } else {
+          formattedResult = processRowResults(
+            result.row_set,
+            eliminateNullRows,
+            _datumEnum
+          )
+        }
 
-      formattedResult.timing = {
-        execution_time_ms: result.execution_time_ms,
-        total_time_ms: result.total_time_ms
+        formattedResult.timing = {
+          execution_time_ms: result.execution_time_ms,
+          total_time_ms: result.total_time_ms
+        }
+      } catch (err) {
+        if (hasCallback) {
+          callback(err)
+        } else {
+          throw err
+        }
+        return
       }
 
       if (hasCallback) {

--- a/src/process-row-results.js
+++ b/src/process-row-results.js
@@ -78,7 +78,7 @@ export default function processRowResults(data, eliminateNullRows, datumEnum) {
               row[fieldName].push(elemDatum.val.int_val * 1000) // eslint-disable-line no-magic-numbers
               break
             default:
-              break
+              throw new Error("Unrecognized array field type: " + fieldType)
           }
         }
       } else {
@@ -109,8 +109,14 @@ export default function processRowResults(data, eliminateNullRows, datumEnum) {
           case "DATE":
             row[fieldName] = new Date(scalarDatum.val.int_val * 1000) // eslint-disable-line no-magic-numbers
             break
-          default:
+          case "POINT":
+          case "LINESTRING":
+          case "POLYGON":
+          case "MULTIPOLYGON":
+            row[fieldName] = scalarDatum.val.str_val
             break
+          default:
+            throw new Error("Unrecognized field type: " + fieldType)
         }
       }
     }


### PR DESCRIPTION
# Merge Checklist
## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR:
- [ ] Fixes #0

Geo types will be returned as WKT strings, so we just return the data as a string in the connector.

Future work will allow setting a geo return type per session.

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
