### PR TITLE
Add getFirstGeoFileInArchiveAsync client method

### DIFF
--- a/dist/browser-connector.js
+++ b/dist/browser-connector.js
@@ -365,6 +365,9 @@
 	      });
 	    };
 
+	    this.getFirstGeoFileInArchiveAsync = this.promisifySingle(function (args) {
+	      return args;
+	    }, "get_first_geo_file_in_archive");
 	    this.getUsersAsync = this.promisifySingle(function (args) {
 	      return args;
 	    }, "get_users");
@@ -776,7 +779,7 @@
 	     * @param {String} imageHash The numeric hash of the dashboard thumbnail.
 	     * @param {String} metaData - Stringified metadata related to the view.
 	     * @return {Promise} Returns empty if successful.
-	      *
+	     *
 	     * @example <caption>Add a new dashboard to the server:</caption>
 	     *
 	     * con.createFrontendViewAsync('newSave', 'viewstateBase64', null, 'metaData').then(res => console.log(res))
@@ -823,7 +826,7 @@
 	    /**
 	     * Delete a dashboard object containing a value for the <code>viewState</code> property.
 	     * @param {String} viewName The name of the dashboard.
-	     * @return {Promise.<String>} The name of dashboard deleted. 
+	     * @return {Promise.<String>} The name of dashboard deleted.
 	     *
 	     * @example <caption>Delete a specific dashboard from the server:</caption>
 	     *
@@ -895,6 +898,18 @@
 	      var thriftCopyParams = helpers.convertObjectToThriftCopyParams(copyParams);
 	      this._client[0].detect_column_types(this._sessionId[0], fileName, thriftCopyParams, callback);
 	    }
+
+	    /**
+	     * Get the first geo file in an archive, if present (to determine if the archive should be treated as geo)
+	     * @param {String} archivePath - The base filename of the archive.
+	     * @param {TCopyParams} copyParams See {@link TCopyParams}.
+	     * @returns {Promise.<String>} Full file path to the found geo file, or the original archivePath otherwise
+	     *
+	     * @example <caption>Get the first geo file in an archive:</caption>
+	     *
+	     * con.getFirstGeoFileInArchiveAsync('archive.zip', {}).then(res => console.log(res))
+	     */
+
 
 	    /**
 	     * Get a list of all users on the database for this connection.

--- a/dist/node-connector.js
+++ b/dist/node-connector.js
@@ -16946,6 +16946,9 @@ module.exports =
 	      });
 	    };
 
+	    this.getFirstGeoFileInArchiveAsync = this.promisifySingle(function (args) {
+	      return args;
+	    }, "get_first_geo_file_in_archive");
 	    this.getUsersAsync = this.promisifySingle(function (args) {
 	      return args;
 	    }, "get_users");
@@ -17357,7 +17360,7 @@ module.exports =
 	     * @param {String} imageHash The numeric hash of the dashboard thumbnail.
 	     * @param {String} metaData - Stringified metadata related to the view.
 	     * @return {Promise} Returns empty if successful.
-	      *
+	     *
 	     * @example <caption>Add a new dashboard to the server:</caption>
 	     *
 	     * con.createFrontendViewAsync('newSave', 'viewstateBase64', null, 'metaData').then(res => console.log(res))
@@ -17404,7 +17407,7 @@ module.exports =
 	    /**
 	     * Delete a dashboard object containing a value for the <code>viewState</code> property.
 	     * @param {String} viewName The name of the dashboard.
-	     * @return {Promise.<String>} The name of dashboard deleted. 
+	     * @return {Promise.<String>} The name of dashboard deleted.
 	     *
 	     * @example <caption>Delete a specific dashboard from the server:</caption>
 	     *
@@ -17476,6 +17479,18 @@ module.exports =
 	      var thriftCopyParams = helpers.convertObjectToThriftCopyParams(copyParams);
 	      this._client[0].detect_column_types(this._sessionId[0], fileName, thriftCopyParams, callback);
 	    }
+
+	    /**
+	     * Get the first geo file in an archive, if present (to determine if the archive should be treated as geo)
+	     * @param {String} archivePath - The base filename of the archive.
+	     * @param {TCopyParams} copyParams See {@link TCopyParams}.
+	     * @returns {Promise.<String>} Full file path to the found geo file, or the original archivePath otherwise
+	     *
+	     * @example <caption>Get the first geo file in an archive:</caption>
+	     *
+	     * con.getFirstGeoFileInArchiveAsync('archive.zip', {}).then(res => console.log(res))
+	     */
+
 
 	    /**
 	     * Get a list of all users on the database for this connection.

--- a/src/mapd-con-es6.js
+++ b/src/mapd-con-es6.js
@@ -523,7 +523,7 @@ class MapdCon {
    * @param {String} imageHash The numeric hash of the dashboard thumbnail.
    * @param {String} metaData - Stringified metadata related to the view.
    * @return {Promise} Returns empty if successful.
-    *
+   *
    * @example <caption>Add a new dashboard to the server:</caption>
    *
    * con.createFrontendViewAsync('newSave', 'viewstateBase64', null, 'metaData').then(res => console.log(res))
@@ -584,7 +584,7 @@ class MapdCon {
   /**
    * Delete a dashboard object containing a value for the <code>viewState</code> property.
    * @param {String} viewName The name of the dashboard.
-   * @return {Promise.<String>} The name of dashboard deleted. 
+   * @return {Promise.<String>} The name of dashboard deleted.
    *
    * @example <caption>Delete a specific dashboard from the server:</caption>
    *
@@ -687,6 +687,21 @@ class MapdCon {
       callback
     )
   }
+
+  /**
+   * Get the first geo file in an archive, if present (to determine if the archive should be treated as geo)
+   * @param {String} archivePath - The base filename of the archive.
+   * @param {TCopyParams} copyParams See {@link TCopyParams}.
+   * @returns {Promise.<String>} Full file path to the found geo file, or the original archivePath otherwise
+   *
+   * @example <caption>Get the first geo file in an archive:</caption>
+   *
+   * con.getFirstGeoFileInArchiveAsync('archive.zip', {}).then(res => console.log(res))
+   */
+  getFirstGeoFileInArchiveAsync = this.promisifySingle(
+    args => args,
+    "get_first_geo_file_in_archive"
+  )
 
   /**
    * Get a list of all users on the database for this connection.


### PR DESCRIPTION
Add (async-only) client method for new getFirstGeoFileInArchive Thrift endpoint.

# Merge Checklist
## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR:
- [ ] Supports https://github.com/mapd/mapd-immerse/issues/4541

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
