### PR TITLE
Don't strip precision from row descriptors FE-5201

### DIFF
--- a/dist/browser-connector.js
+++ b/dist/browser-connector.js
@@ -1961,6 +1961,8 @@
 	    thriftRowDescArray[i].col_name = obj.clean_col_name;
 	    thriftRowDescArray[i].col_type.encoding = obj.col_type.encoding;
 	    thriftRowDescArray[i].col_type.precision = obj.col_type.precision;
+	    thriftRowDescArray[i].col_type.comp_param = obj.col_type.comp_param;
+	    thriftRowDescArray[i].col_type.scale = obj.col_type.scale;
 	    thriftRowDescArray[i].col_type.type = obj.col_type.type;
 	  });
 	  return thriftRowDescArray;

--- a/dist/browser-connector.js
+++ b/dist/browser-connector.js
@@ -1960,6 +1960,7 @@
 	  rowDescArray.forEach(function (obj, i) {
 	    thriftRowDescArray[i].col_name = obj.clean_col_name;
 	    thriftRowDescArray[i].col_type.encoding = obj.col_type.encoding;
+	    thriftRowDescArray[i].col_type.precision = obj.col_type.precision;
 	    thriftRowDescArray[i].col_type.type = obj.col_type.type;
 	  });
 	  return thriftRowDescArray;

--- a/dist/node-connector.js
+++ b/dist/node-connector.js
@@ -18609,6 +18609,8 @@ module.exports =
 	    thriftRowDescArray[i].col_name = obj.clean_col_name;
 	    thriftRowDescArray[i].col_type.encoding = obj.col_type.encoding;
 	    thriftRowDescArray[i].col_type.precision = obj.col_type.precision;
+	    thriftRowDescArray[i].col_type.comp_param = obj.col_type.comp_param;
+	    thriftRowDescArray[i].col_type.scale = obj.col_type.scale;
 	    thriftRowDescArray[i].col_type.type = obj.col_type.type;
 	  });
 	  return thriftRowDescArray;

--- a/dist/node-connector.js
+++ b/dist/node-connector.js
@@ -18608,6 +18608,7 @@ module.exports =
 	  rowDescArray.forEach(function (obj, i) {
 	    thriftRowDescArray[i].col_name = obj.clean_col_name;
 	    thriftRowDescArray[i].col_type.encoding = obj.col_type.encoding;
+	    thriftRowDescArray[i].col_type.precision = obj.col_type.precision;
 	    thriftRowDescArray[i].col_type.type = obj.col_type.type;
 	  });
 	  return thriftRowDescArray;

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -4,6 +4,7 @@ export const mutateThriftRowDesc = (rowDescArray, thriftRowDescArray) => {
   rowDescArray.forEach((obj, i) => {
     thriftRowDescArray[i].col_name = obj.clean_col_name
     thriftRowDescArray[i].col_type.encoding = obj.col_type.encoding
+    thriftRowDescArray[i].col_type.precision = obj.col_type.precision
     thriftRowDescArray[i].col_type.type = obj.col_type.type
   })
   return thriftRowDescArray

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -5,6 +5,8 @@ export const mutateThriftRowDesc = (rowDescArray, thriftRowDescArray) => {
     thriftRowDescArray[i].col_name = obj.clean_col_name
     thriftRowDescArray[i].col_type.encoding = obj.col_type.encoding
     thriftRowDescArray[i].col_type.precision = obj.col_type.precision
+    thriftRowDescArray[i].col_type.comp_param = obj.col_type.comp_param
+    thriftRowDescArray[i].col_type.scale = obj.col_type.scale
     thriftRowDescArray[i].col_type.type = obj.col_type.type
   })
   return thriftRowDescArray

--- a/test/helpers.unit.spec.js
+++ b/test/helpers.unit.spec.js
@@ -25,7 +25,9 @@ describe("helpers", () => {
             type: 0,
             is_array: false,
             nullable: false,
-            precision: 0
+            precision: 0,
+            comp_param: 0,
+            scale: 0
           }
         },
         {
@@ -36,7 +38,9 @@ describe("helpers", () => {
             type: 0,
             is_array: false,
             nullable: false,
-            precision: 3
+            precision: 3,
+            comp_param: 0,
+            scale: 0
           }
         }
       ]
@@ -50,7 +54,9 @@ describe("helpers", () => {
             type: 0,
             is_array: false,
             nullable: false,
-            precision: 0
+            precision: 0,
+            comp_param: 0,
+            scale: 0
           }
         },
         {
@@ -61,7 +67,9 @@ describe("helpers", () => {
             type: 0,
             is_array: false,
             nullable: false,
-            precision: 3
+            precision: 3,
+            comp_param: 0,
+            scale: 0
           }
         }
       ]
@@ -75,7 +83,9 @@ describe("helpers", () => {
             type: 0,
             is_array: false,
             nullable: false,
-            precision: 0
+            precision: 0,
+            comp_param: 0,
+            scale: 0
           }
         },
         {
@@ -86,7 +96,9 @@ describe("helpers", () => {
             type: 0,
             is_array: false,
             nullable: false,
-            precision: 3
+            precision: 3,
+            comp_param: 0,
+            scale: 0
           }
         }
       ])

--- a/test/helpers.unit.spec.js
+++ b/test/helpers.unit.spec.js
@@ -24,7 +24,8 @@ describe("helpers", () => {
             encoding: 0,
             type: 0,
             is_array: false,
-            nullable: false
+            nullable: false,
+            precision: 0
           }
         },
         {
@@ -34,7 +35,8 @@ describe("helpers", () => {
             encoding: 0,
             type: 0,
             is_array: false,
-            nullable: false
+            nullable: false,
+            precision: 3
           }
         }
       ]
@@ -47,7 +49,8 @@ describe("helpers", () => {
             encoding: 0,
             type: 0,
             is_array: false,
-            nullable: false
+            nullable: false,
+            precision: 0
           }
         },
         {
@@ -57,7 +60,8 @@ describe("helpers", () => {
             encoding: 0,
             type: 0,
             is_array: false,
-            nullable: false
+            nullable: false,
+            precision: 3
           }
         }
       ]
@@ -70,7 +74,8 @@ describe("helpers", () => {
             encoding: 0,
             type: 0,
             is_array: false,
-            nullable: false
+            nullable: false,
+            precision: 0
           }
         },
         {
@@ -80,7 +85,8 @@ describe("helpers", () => {
             encoding: 0,
             type: 0,
             is_array: false,
-            nullable: false
+            nullable: false,
+            precision: 3
           }
         }
       ])


### PR DESCRIPTION
In the table create service, the helper function `mutateThriftRowDesc()` was stripping out the `precision` property of a row descriptor. This was causing problems with the PR mapd/mapd-immerse#4920, which adds support for setting higher-precision timestamps (ms, us, ns) in the table importer. The bug in mapd-connector meant that, even though the precision of the column was being set to a non-zero value, that precision wasn't getting passed to the backend.

This commit fixes the bug by ensuring the precision property of a row descriptor is retained and passed to the backend intact. This allows us to successfully set the precision in Immerse, and have the backend respect that precision.

Two questions for @arittr: 
1. Should I bump the version in `package.json` and/or tag the commit?
2. I see there's a branch by @mapd-bot. `mapd-bot/new-thirft`. Should that be merged first and/or should I rebase onto that branch?

# Merge Checklist
## :wrench: Issue(s) fixed:
- [x] Author referenced issue(s) fixed by this PR: mapd/mapd-immerse#4920

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [x] author crafted PR's title into release-worthy commit message.
